### PR TITLE
feat: implement CPU worker pool for async book ingest

### DIFF
--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -1,0 +1,123 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+
+	"github.com/jackzampolin/shelf/internal/jobs"
+)
+
+// ExtractPageHandler returns a CPUTaskHandler that extracts a single page from a PDF.
+// This handler is registered on CPU workers to process page extraction work units.
+func ExtractPageHandler() jobs.CPUTaskHandler {
+	return func(ctx context.Context, req *jobs.CPUWorkRequest) (*jobs.CPUWorkResult, error) {
+		// Type assert the data
+		pageReq, ok := req.Data.(PageExtractRequest)
+		if !ok {
+			// Try map conversion (happens when deserializing from JSON)
+			if m, ok := req.Data.(map[string]any); ok {
+				pageReq = PageExtractRequest{
+					PDFPath:   m["PDFPath"].(string),
+					PageNum:   int(m["PageNum"].(float64)),
+					OutputNum: int(m["OutputNum"].(float64)),
+					OutputDir: m["OutputDir"].(string),
+				}
+			} else {
+				return nil, fmt.Errorf("invalid data type for extract-page task: %T", req.Data)
+			}
+		}
+
+		// Extract the page
+		outputPath, err := extractSinglePage(ctx, pageReq)
+		if err != nil {
+			return nil, err
+		}
+
+		return &jobs.CPUWorkResult{
+			Data: PageExtractResult{
+				OutputPath: outputPath,
+				PageNum:    pageReq.OutputNum,
+			},
+		}, nil
+	}
+}
+
+// extractSinglePage extracts a single page from a PDF and writes it to the output directory.
+func extractSinglePage(ctx context.Context, req PageExtractRequest) (string, error) {
+	// Check for cancellation
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
+	conf := model.NewDefaultConfiguration()
+	conf.ValidationMode = model.ValidationRelaxed
+
+	// Try to decrypt to remove permission restrictions
+	workingPath, err := decryptPDF(req.PDFPath, conf)
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare PDF: %w", err)
+	}
+	if workingPath != req.PDFPath {
+		defer os.Remove(workingPath)
+	}
+
+	// Create temp directory for extraction
+	tmpDir, err := os.MkdirTemp("", "shelf-page-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Extract just this page
+	pages := []string{strconv.Itoa(req.PageNum)}
+	if err := api.ExtractImagesFile(workingPath, tmpDir, pages, conf); err != nil {
+		return "", fmt.Errorf("pdfcpu extract failed: %w", err)
+	}
+
+	// Read extracted file (there should be exactly one)
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read temp dir: %w", err)
+	}
+
+	// Filter out directories
+	var files []os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() {
+			files = append(files, e)
+		}
+	}
+
+	if len(files) == 0 {
+		return "", fmt.Errorf("no image extracted for page %d", req.PageNum)
+	}
+
+	// Sort files to get consistent ordering
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Name() < files[j].Name()
+	})
+
+	// Read the extracted image
+	srcPath := filepath.Join(tmpDir, files[0].Name())
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read extracted image: %w", err)
+	}
+
+	// Write to destination with sequential naming
+	dstPath := filepath.Join(req.OutputDir, fmt.Sprintf("page_%04d.png", req.OutputNum))
+	if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+		return "", fmt.Errorf("failed to write page image: %w", err)
+	}
+
+	return dstPath, nil
+}

--- a/internal/ingest/job.go
+++ b/internal/ingest/job.go
@@ -1,0 +1,342 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+
+	"github.com/jackzampolin/shelf/internal/defra"
+	"github.com/jackzampolin/shelf/internal/home"
+	"github.com/jackzampolin/shelf/internal/jobs"
+)
+
+const (
+	JobType         = "ingest"
+	TaskExtractPage = "extract-page"
+)
+
+// PageExtractRequest is the data for a single page extraction work unit.
+type PageExtractRequest struct {
+	PDFPath   string // Source PDF file
+	PageNum   int    // Page number within the PDF (1-indexed)
+	OutputNum int    // Output page number (for sequential naming across PDFs)
+	OutputDir string // Directory to write the extracted page
+}
+
+// PageExtractResult is returned from a successful page extraction.
+type PageExtractResult struct {
+	OutputPath string // Path to the extracted image
+	PageNum    int    // Output page number
+}
+
+// Job implements jobs.Job for ingesting book scans.
+// It discovers pages across all input PDFs, then farms out
+// individual page extractions to CPU workers.
+type Job struct {
+	mu sync.Mutex
+
+	// Configuration
+	pdfPaths []string
+	title    string
+	author   string
+	bookID   string // Generated UUID, later replaced with DefraDB docID
+	logger   *slog.Logger
+
+	// Dependencies (set via SetDependencies)
+	defraClient *defra.Client
+	homeDir     *home.Dir
+
+	// State
+	recordID       string // DefraDB job record ID
+	outputDir      string
+	totalPages     int
+	completedPages int
+	failedPages    int
+	done           bool
+	finalBookID    string // DefraDB Book docID after completion
+}
+
+// JobConfig configures a new ingest job.
+type JobConfig struct {
+	PDFPaths []string
+	Title    string
+	Author   string
+	Logger   *slog.Logger
+}
+
+// NewJob creates a new ingest job.
+func NewJob(cfg JobConfig) *Job {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Sort PDFs by numeric suffix
+	sortedPaths := sortPDFsByNumber(cfg.PDFPaths)
+
+	// Derive title from first PDF if not provided
+	title := cfg.Title
+	if title == "" && len(sortedPaths) > 0 {
+		title = deriveTitle(sortedPaths[0])
+	}
+
+	return &Job{
+		pdfPaths: sortedPaths,
+		title:    title,
+		author:   cfg.Author,
+		bookID:   uuid.New().String(),
+		logger:   logger.With("job_type", JobType),
+	}
+}
+
+// SetDependencies sets the DefraDB client and home directory.
+// Must be called before submitting the job to the scheduler.
+func (j *Job) SetDependencies(client *defra.Client, homeDir *home.Dir) {
+	j.defraClient = client
+	j.homeDir = homeDir
+}
+
+// ID returns the DefraDB record ID for this job.
+func (j *Job) ID() string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.recordID
+}
+
+// SetRecordID sets the DefraDB record ID.
+func (j *Job) SetRecordID(id string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.recordID = id
+}
+
+// Type returns the job type identifier.
+func (j *Job) Type() string {
+	return JobType
+}
+
+// Start initializes the job and returns work units for each page.
+func (j *Job) Start(ctx context.Context) ([]jobs.WorkUnit, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	// Validate PDFs exist
+	for _, p := range j.pdfPaths {
+		if _, err := os.Stat(p); err != nil {
+			return nil, fmt.Errorf("PDF not found: %s", p)
+		}
+	}
+
+	// Create output directory
+	if err := j.homeDir.EnsureSourceImagesDir(j.bookID); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	j.outputDir = j.homeDir.SourceImagesDir(j.bookID)
+
+	j.logger.Info("starting ingest job",
+		"pdfs", len(j.pdfPaths),
+		"title", j.title,
+		"output_dir", j.outputDir,
+	)
+
+	// Discovery: count pages in all PDFs
+	conf := model.NewDefaultConfiguration()
+	conf.ValidationMode = model.ValidationRelaxed
+
+	var units []jobs.WorkUnit
+	outputNum := 1
+
+	for _, pdfPath := range j.pdfPaths {
+		// Try to decrypt to remove permission restrictions
+		workingPath, err := decryptPDF(pdfPath, conf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare PDF %s: %w", pdfPath, err)
+		}
+
+		// Get page count
+		f, err := os.Open(workingPath)
+		if err != nil {
+			if workingPath != pdfPath {
+				os.Remove(workingPath)
+			}
+			return nil, fmt.Errorf("failed to open PDF %s: %w", pdfPath, err)
+		}
+		pageCount, err := api.PageCount(f, nil)
+		f.Close()
+		if err != nil {
+			if workingPath != pdfPath {
+				os.Remove(workingPath)
+			}
+			return nil, fmt.Errorf("failed to get page count for %s: %w", pdfPath, err)
+		}
+
+		// Clean up temp file if we created one
+		if workingPath != pdfPath {
+			os.Remove(workingPath)
+		}
+
+		j.logger.Info("discovered PDF",
+			"file", filepath.Base(pdfPath),
+			"pages", pageCount,
+		)
+
+		// Create work unit for each page
+		for pageNum := 1; pageNum <= pageCount; pageNum++ {
+			units = append(units, jobs.WorkUnit{
+				ID:   fmt.Sprintf("%s-page-%d", j.bookID, outputNum),
+				Type: jobs.WorkUnitTypeCPU,
+				CPURequest: &jobs.CPUWorkRequest{
+					Task: TaskExtractPage,
+					Data: PageExtractRequest{
+						PDFPath:   pdfPath,
+						PageNum:   pageNum,
+						OutputNum: outputNum,
+						OutputDir: j.outputDir,
+					},
+				},
+			})
+			outputNum++
+		}
+	}
+
+	j.totalPages = len(units)
+	j.logger.Info("created work units", "total_pages", j.totalPages)
+
+	return units, nil
+}
+
+// OnComplete is called when a work unit finishes.
+func (j *Job) OnComplete(ctx context.Context, result jobs.WorkResult) ([]jobs.WorkUnit, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if result.Success {
+		j.completedPages++
+		j.logger.Debug("page extracted",
+			"completed", j.completedPages,
+			"total", j.totalPages,
+		)
+	} else {
+		j.failedPages++
+		j.logger.Warn("page extraction failed",
+			"unit_id", result.WorkUnitID,
+			"error", result.Error,
+		)
+	}
+
+	// Check if all pages are done
+	if j.completedPages+j.failedPages >= j.totalPages {
+		if err := j.finalize(ctx); err != nil {
+			j.logger.Error("failed to finalize job", "error", err)
+			return nil, err
+		}
+		j.done = true
+	}
+
+	return nil, nil
+}
+
+// finalize creates the Book record in DefraDB after all pages are extracted.
+// Must be called with lock held.
+func (j *Job) finalize(ctx context.Context) error {
+	if j.failedPages > 0 {
+		// Clean up on failure
+		os.RemoveAll(j.outputDir)
+		return fmt.Errorf("ingest failed: %d pages failed to extract", j.failedPages)
+	}
+
+	j.logger.Info("finalizing ingest",
+		"title", j.title,
+		"pages", j.completedPages,
+	)
+
+	// Create Book record in DefraDB
+	input := map[string]any{
+		"title":      j.title,
+		"page_count": j.completedPages,
+		"status":     "ingested",
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+	}
+	if j.author != "" {
+		input["author"] = j.author
+	}
+
+	docID, err := j.defraClient.Create(ctx, "Book", input)
+	if err != nil {
+		os.RemoveAll(j.outputDir)
+		return fmt.Errorf("failed to create Book record: %w", err)
+	}
+
+	// Rename directory from UUID to docID
+	newDir := j.homeDir.SourceImagesDir(docID)
+	if err := os.Rename(j.outputDir, newDir); err != nil {
+		return fmt.Errorf("failed to rename directory: %w", err)
+	}
+
+	j.finalBookID = docID
+	j.logger.Info("ingest complete",
+		"book_id", docID,
+		"pages", j.completedPages,
+	)
+
+	return nil
+}
+
+// Done returns true when the job has completed.
+func (j *Job) Done() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.done
+}
+
+// Status returns the current status of the job.
+func (j *Job) Status(ctx context.Context) (map[string]string, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	status := map[string]string{
+		"title":           j.title,
+		"total_pages":     fmt.Sprintf("%d", j.totalPages),
+		"completed_pages": fmt.Sprintf("%d", j.completedPages),
+		"failed_pages":    fmt.Sprintf("%d", j.failedPages),
+	}
+
+	if j.author != "" {
+		status["author"] = j.author
+	}
+	if j.finalBookID != "" {
+		status["book_id"] = j.finalBookID
+	}
+
+	return status, nil
+}
+
+// Progress returns per-provider work unit progress.
+func (j *Job) Progress() map[string]jobs.ProviderProgress {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	return map[string]jobs.ProviderProgress{
+		"cpu": {
+			TotalExpected: j.totalPages,
+			Completed:     j.completedPages,
+			Failed:        j.failedPages,
+		},
+	}
+}
+
+// BookID returns the DefraDB Book document ID after successful completion.
+// Returns empty string if job is not yet complete.
+func (j *Job) BookID() string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.finalBookID
+}

--- a/internal/jobs/cpu_worker.go
+++ b/internal/jobs/cpu_worker.go
@@ -1,0 +1,177 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+const (
+	WorkerTypeCPU WorkerType = "cpu"
+)
+
+// CPUTaskHandler processes a CPU work request and returns a result.
+// Implementations should be safe for concurrent use.
+type CPUTaskHandler func(ctx context.Context, req *CPUWorkRequest) (*CPUWorkResult, error)
+
+// CPUWorker handles CPU-bound work without rate limiting.
+// Unlike LLM/OCR workers, CPU workers don't wrap external providers.
+// Instead, they execute registered task handlers.
+type CPUWorker struct {
+	name      string
+	logger    *slog.Logger
+	queueSize int
+
+	// Queue for incoming work units (owned by this worker)
+	queue chan *WorkUnit
+
+	// Results channel (shared, set by scheduler)
+	results chan<- workerResult
+
+	// Task handlers by task name
+	handlers map[string]CPUTaskHandler
+	mu       sync.RWMutex
+}
+
+// CPUWorkerConfig configures a new CPU worker.
+type CPUWorkerConfig struct {
+	Name      string
+	Logger    *slog.Logger
+	QueueSize int // Default 100
+}
+
+// NewCPUWorker creates a new CPU worker.
+func NewCPUWorker(cfg CPUWorkerConfig) *CPUWorker {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	queueSize := cfg.QueueSize
+	if queueSize <= 0 {
+		queueSize = 10000 // Large queue for CPU work (many pages per book)
+	}
+
+	name := cfg.Name
+	if name == "" {
+		name = "cpu"
+	}
+
+	return &CPUWorker{
+		name:      name,
+		logger:    logger.With("worker", name, "type", WorkerTypeCPU),
+		queueSize: queueSize,
+		handlers:  make(map[string]CPUTaskHandler),
+	}
+}
+
+// RegisterHandler registers a handler for a task type.
+// Must be called before Start.
+func (w *CPUWorker) RegisterHandler(taskName string, handler CPUTaskHandler) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.handlers[taskName] = handler
+	w.logger.Debug("registered CPU task handler", "task", taskName)
+}
+
+// Name returns the worker name.
+func (w *CPUWorker) Name() string {
+	return w.name
+}
+
+// Type returns WorkerTypeCPU.
+func (w *CPUWorker) Type() WorkerType {
+	return WorkerTypeCPU
+}
+
+// init initializes the worker's queue and sets the results channel.
+// Called by the scheduler before Start.
+func (w *CPUWorker) init(results chan<- workerResult) {
+	w.queue = make(chan *WorkUnit, w.queueSize)
+	w.results = results
+}
+
+// Start runs the worker's processing loop.
+// Blocks until context is cancelled. Run in a goroutine.
+func (w *CPUWorker) Start(ctx context.Context) {
+	// Don't log individual worker starts - scheduler logs the count
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Don't log individual worker stops - too noisy
+			return
+
+		case unit := <-w.queue:
+			result := w.process(ctx, unit)
+			w.results <- workerResult{
+				JobID:  unit.JobID,
+				Unit:   unit,
+				Result: result,
+			}
+		}
+	}
+}
+
+// Submit adds a work unit to this worker's queue.
+// Returns an error if the queue is full.
+func (w *CPUWorker) Submit(unit *WorkUnit) error {
+	select {
+	case w.queue <- unit:
+		return nil
+	default:
+		return fmt.Errorf("%w: %s", ErrWorkerQueueFull, w.name)
+	}
+}
+
+// QueueDepth returns the number of items in the worker's queue.
+func (w *CPUWorker) QueueDepth() int {
+	return len(w.queue)
+}
+
+// process executes a CPU work unit.
+func (w *CPUWorker) process(ctx context.Context, unit *WorkUnit) WorkResult {
+	result := WorkResult{
+		WorkUnitID: unit.ID,
+	}
+
+	// Validate work unit type
+	if unit.Type != WorkUnitTypeCPU {
+		result.Success = false
+		result.Error = fmt.Errorf("work unit type %s does not match worker type cpu", unit.Type)
+		return result
+	}
+
+	if unit.CPURequest == nil {
+		result.Success = false
+		result.Error = fmt.Errorf("CPU work unit missing CPURequest")
+		return result
+	}
+
+	// Find handler for this task
+	w.mu.RLock()
+	handler, ok := w.handlers[unit.CPURequest.Task]
+	w.mu.RUnlock()
+
+	if !ok {
+		result.Success = false
+		result.Error = fmt.Errorf("no handler registered for CPU task: %s", unit.CPURequest.Task)
+		return result
+	}
+
+	// Execute handler (no rate limiting for CPU work)
+	cpuResult, err := handler(ctx, unit.CPURequest)
+	if err != nil {
+		result.Success = false
+		result.Error = err
+		w.logger.Debug("CPU work unit failed", "unit_id", unit.ID, "task", unit.CPURequest.Task, "error", err)
+		return result
+	}
+
+	result.Success = true
+	result.CPUResult = cpuResult
+	w.logger.Debug("CPU work unit completed", "unit_id", unit.ID, "task", unit.CPURequest.Task)
+
+	return result
+}

--- a/internal/jobs/scheduler_test.go
+++ b/internal/jobs/scheduler_test.go
@@ -279,32 +279,40 @@ func TestScheduler_InitFromRegistry(t *testing.T) {
 	}
 
 	// Verify LLM worker
-	llmWorker, ok := scheduler.GetWorker("openrouter")
+	llmWorkerIface, ok := scheduler.GetWorker("openrouter")
 	if !ok {
 		t.Error("openrouter worker not found")
 	} else {
-		if llmWorker.Type() != WorkerTypeLLM {
-			t.Errorf("openrouter Type = %s, want llm", llmWorker.Type())
+		if llmWorkerIface.Type() != WorkerTypeLLM {
+			t.Errorf("openrouter Type = %s, want llm", llmWorkerIface.Type())
 		}
-		// Verify rate limit was passed through
-		status := llmWorker.RateLimiterStatus()
-		if status.RPS != 120 {
-			t.Errorf("openrouter RPS = %f, want 120", status.RPS)
+		// Verify rate limit was passed through (cast to *Worker for rate limiter access)
+		if llmWorker, ok := llmWorkerIface.(*Worker); ok {
+			status := llmWorker.RateLimiterStatus()
+			if status.RPS != 120 {
+				t.Errorf("openrouter RPS = %f, want 120", status.RPS)
+			}
+		} else {
+			t.Error("openrouter worker is not a *Worker")
 		}
 	}
 
 	// Verify OCR worker
-	ocrWorker, ok := scheduler.GetWorker("mistral")
+	ocrWorkerIface, ok := scheduler.GetWorker("mistral")
 	if !ok {
 		t.Error("mistral worker not found")
 	} else {
-		if ocrWorker.Type() != WorkerTypeOCR {
-			t.Errorf("mistral Type = %s, want ocr", ocrWorker.Type())
+		if ocrWorkerIface.Type() != WorkerTypeOCR {
+			t.Errorf("mistral Type = %s, want ocr", ocrWorkerIface.Type())
 		}
-		// Verify rate limit was passed through
-		status := ocrWorker.RateLimiterStatus()
-		if status.RPS != 10.0 {
-			t.Errorf("mistral RPS = %f, want 10.0", status.RPS)
+		// Verify rate limit was passed through (cast to *Worker for rate limiter access)
+		if ocrWorker, ok := ocrWorkerIface.(*Worker); ok {
+			status := ocrWorker.RateLimiterStatus()
+			if status.RPS != 10.0 {
+				t.Errorf("mistral RPS = %f, want 10.0", status.RPS)
+			}
+		} else {
+			t.Error("mistral worker is not a *Worker")
 		}
 	}
 }

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -8,13 +8,24 @@ import (
 	"github.com/jackzampolin/shelf/internal/providers"
 )
 
-// WorkerType indicates whether this worker handles LLM or OCR work.
+// WorkerType indicates what kind of work this worker handles.
 type WorkerType string
 
 const (
 	WorkerTypeLLM WorkerType = "llm"
 	WorkerTypeOCR WorkerType = "ocr"
 )
+
+// WorkerInterface is implemented by all worker types.
+// This allows the scheduler to manage different worker implementations uniformly.
+type WorkerInterface interface {
+	Name() string
+	Type() WorkerType
+	Start(ctx context.Context)
+	Submit(unit *WorkUnit) error
+	QueueDepth() int
+	init(results chan<- workerResult)
+}
 
 // Worker wraps a single provider (LLM or OCR) with rate limiting.
 // Each worker owns its own input queue and runs as a single goroutine.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackzampolin/shelf/internal/config"
 	"github.com/jackzampolin/shelf/internal/defra"
 	"github.com/jackzampolin/shelf/internal/home"
+	"github.com/jackzampolin/shelf/internal/ingest"
 	"github.com/jackzampolin/shelf/internal/jobs"
 	"github.com/jackzampolin/shelf/internal/providers"
 	"github.com/jackzampolin/shelf/internal/schema"
@@ -193,6 +194,12 @@ func (s *Server) Start(ctx context.Context) error {
 		_ = s.shutdown()
 		return fmt.Errorf("failed to initialize workers: %w", err)
 	}
+
+	// Initialize CPU workers for CPU-bound tasks (uses runtime.NumCPU())
+	s.scheduler.InitCPUWorkers(0)
+
+	// Register CPU task handlers
+	s.scheduler.RegisterCPUHandler(ingest.TaskExtractPage, ingest.ExtractPageHandler())
 
 	// Start scheduler in background
 	go s.scheduler.Start(ctx)


### PR DESCRIPTION
## Summary

- Adds CPU-bound worker system to job scheduler for ingest operations
- Books now ingested asynchronously with page extractions distributed across `numCPU()` workers
- Ingest endpoint returns job ID immediately for progress polling
- Multiple books can be queued and processed in parallel through the same worker pool

## Changes

- Add `WorkUnitTypeCPU` and `CPUWorker` for CPU-bound tasks (no rate limiting)
- Add `WorkerInterface` for polymorphic worker handling in scheduler
- Add `Scheduler.InitCPUWorkers()` with round-robin work distribution
- Create `IngestJob` implementing `jobs.Job` interface
- Update `/api/books/ingest` to submit job and return job ID
- Register CPU workers and `extract-page` handler on server startup

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./...`)
- [x] Manual test: ingest single PDF - pages extracted correctly
- [x] Manual test: ingest multiple PDFs - parallel processing works
- [ ] Add unit tests for CPUWorker and IngestJob

🤖 Generated with [Claude Code](https://claude.com/claude-code)