### PR TITLE
feat: redesign book detail page with tabbed layout

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -136,6 +136,31 @@ func (c *Client) Delete(ctx context.Context, path string) error {
 	return c.handleResponse(resp, nil)
 }
 
+// GetRaw performs a GET request and returns the raw response body.
+func (c *Client) GetRaw(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
 func (c *Client) handleResponse(resp *http.Response, result any) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/epub/builder.go
+++ b/internal/epub/builder.go
@@ -1,0 +1,293 @@
+// Package epub provides ePub 3.0 generation from processed book data.
+package epub
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Book contains the metadata needed for epub generation.
+type Book struct {
+	ID        string
+	Title     string
+	Author    string
+	Language  string // ISO 639-1 code (e.g., "en")
+	Publisher string
+	ISBN      string
+	CreatedAt time.Time
+}
+
+// Chapter represents a chapter for epub generation.
+type Chapter struct {
+	ID           string // Unique identifier (e.g., "ch_001")
+	Title        string
+	Level        int    // Hierarchy level (1=part, 2=chapter, 3=section)
+	LevelName    string // e.g., "chapter", "part", "epilogue"
+	EntryNumber  string // e.g., "1", "I", "A"
+	MatterType   string // "front_matter", "body", "back_matter"
+	PolishedText string // Markdown-formatted text
+	SortOrder    int
+}
+
+// Builder creates ePub 3.0 files.
+type Builder struct {
+	book     Book
+	chapters []Chapter
+}
+
+// NewBuilder creates a new epub builder.
+func NewBuilder(book Book, chapters []Chapter) *Builder {
+	return &Builder{
+		book:     book,
+		chapters: chapters,
+	}
+}
+
+// Build generates the epub and writes it to the specified path.
+func (b *Builder) Build(outputPath string) error {
+	// Create output directory if needed
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Create output file
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer f.Close()
+
+	return b.WriteTo(f)
+}
+
+// WriteTo writes the epub to a writer.
+func (b *Builder) WriteTo(w io.Writer) error {
+	zw := zip.NewWriter(w)
+	defer zw.Close()
+
+	// 1. Write mimetype (must be first, uncompressed)
+	if err := b.writeMimetype(zw); err != nil {
+		return err
+	}
+
+	// 2. Write META-INF/container.xml
+	if err := b.writeContainer(zw); err != nil {
+		return err
+	}
+
+	// 3. Write OEBPS/content.opf (package document)
+	if err := b.writePackage(zw); err != nil {
+		return err
+	}
+
+	// 4. Write OEBPS/nav.xhtml (navigation)
+	if err := b.writeNavigation(zw); err != nil {
+		return err
+	}
+
+	// 5. Write OEBPS/toc.ncx (NCX for ePub 2 compatibility)
+	if err := b.writeNCX(zw); err != nil {
+		return err
+	}
+
+	// 6. Write OEBPS/styles/style.css
+	if err := b.writeStylesheet(zw); err != nil {
+		return err
+	}
+
+	// 7. Write chapter files
+	for i, ch := range b.chapters {
+		if err := b.writeChapter(zw, i, ch); err != nil {
+			return fmt.Errorf("failed to write chapter %s: %w", ch.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// writeMimetype writes the mimetype file (must be first and uncompressed).
+func (b *Builder) writeMimetype(zw *zip.Writer) error {
+	// Create with Store method (no compression) as required by ePub spec
+	header := &zip.FileHeader{
+		Name:   "mimetype",
+		Method: zip.Store,
+	}
+	w, err := zw.CreateHeader(header)
+	if err != nil {
+		return fmt.Errorf("failed to create mimetype: %w", err)
+	}
+	_, err = w.Write([]byte("application/epub+zip"))
+	return err
+}
+
+// writeContainer writes META-INF/container.xml.
+func (b *Builder) writeContainer(zw *zip.Writer) error {
+	content := `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`
+
+	w, err := zw.Create("META-INF/container.xml")
+	if err != nil {
+		return fmt.Errorf("failed to create container.xml: %w", err)
+	}
+	_, err = w.Write([]byte(content))
+	return err
+}
+
+// writePackage writes OEBPS/content.opf.
+func (b *Builder) writePackage(zw *zip.Writer) error {
+	w, err := zw.Create("OEBPS/content.opf")
+	if err != nil {
+		return fmt.Errorf("failed to create content.opf: %w", err)
+	}
+
+	content := b.generatePackage()
+	_, err = w.Write([]byte(content))
+	return err
+}
+
+// writeNavigation writes OEBPS/nav.xhtml.
+func (b *Builder) writeNavigation(zw *zip.Writer) error {
+	w, err := zw.Create("OEBPS/nav.xhtml")
+	if err != nil {
+		return fmt.Errorf("failed to create nav.xhtml: %w", err)
+	}
+
+	content := b.generateNavigation()
+	_, err = w.Write([]byte(content))
+	return err
+}
+
+// writeNCX writes OEBPS/toc.ncx for ePub 2 compatibility.
+func (b *Builder) writeNCX(zw *zip.Writer) error {
+	w, err := zw.Create("OEBPS/toc.ncx")
+	if err != nil {
+		return fmt.Errorf("failed to create toc.ncx: %w", err)
+	}
+
+	content := b.generateNCX()
+	_, err = w.Write([]byte(content))
+	return err
+}
+
+// writeStylesheet writes OEBPS/styles/style.css.
+func (b *Builder) writeStylesheet(zw *zip.Writer) error {
+	w, err := zw.Create("OEBPS/styles/style.css")
+	if err != nil {
+		return fmt.Errorf("failed to create style.css: %w", err)
+	}
+
+	_, err = w.Write([]byte(defaultStylesheet))
+	return err
+}
+
+// writeChapter writes a single chapter XHTML file.
+func (b *Builder) writeChapter(zw *zip.Writer, index int, ch Chapter) error {
+	filename := fmt.Sprintf("OEBPS/chapters/%s.xhtml", ch.ID)
+	w, err := zw.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", filename, err)
+	}
+
+	content := b.generateChapterXHTML(ch)
+	_, err = w.Write([]byte(content))
+	return err
+}
+
+// generateUUID generates a unique identifier for the epub.
+func (b *Builder) generateUUID() string {
+	if b.book.ISBN != "" {
+		return "urn:isbn:" + b.book.ISBN
+	}
+	return "urn:uuid:" + uuid.New().String()
+}
+
+// BuildToBuffer generates the epub and returns it as a byte buffer.
+func (b *Builder) BuildToBuffer() (*bytes.Buffer, error) {
+	buf := new(bytes.Buffer)
+	if err := b.WriteTo(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+const defaultStylesheet = `/* Shelf ePub Stylesheet */
+
+body {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1em;
+  line-height: 1.6;
+  margin: 1em;
+  text-align: justify;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: bold;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  text-align: left;
+}
+
+h1 {
+  font-size: 1.8em;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.3em;
+}
+
+h2 {
+  font-size: 1.4em;
+}
+
+h3 {
+  font-size: 1.2em;
+}
+
+p {
+  margin: 0.5em 0;
+  text-indent: 1.5em;
+}
+
+p:first-of-type,
+h1 + p, h2 + p, h3 + p {
+  text-indent: 0;
+}
+
+blockquote {
+  margin: 1em 2em;
+  font-style: italic;
+  border-left: 3px solid #ccc;
+  padding-left: 1em;
+}
+
+.chapter-title {
+  text-align: center;
+  margin-top: 3em;
+  margin-bottom: 2em;
+}
+
+.chapter-number {
+  font-size: 0.9em;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5em;
+}
+
+.front-matter, .back-matter {
+  font-size: 0.95em;
+}
+
+.notes {
+  font-size: 0.85em;
+}
+`

--- a/internal/epub/navigation.go
+++ b/internal/epub/navigation.go
@@ -1,0 +1,160 @@
+package epub
+
+import (
+	"fmt"
+	"strings"
+)
+
+// generateNavigation creates the nav.xhtml navigation document.
+func (b *Builder) generateNavigation() string {
+	var sb strings.Builder
+
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+<head>
+  <title>Table of Contents</title>
+  <link rel="stylesheet" type="text/css" href="styles/style.css"/>
+</head>
+<body>
+  <nav epub:type="toc" id="toc">
+    <h1>Table of Contents</h1>
+    <ol>
+`)
+
+	// Group chapters by matter type for better organization
+	var frontMatter, body, backMatter []Chapter
+	for _, ch := range b.chapters {
+		switch ch.MatterType {
+		case "front_matter":
+			frontMatter = append(frontMatter, ch)
+		case "back_matter":
+			backMatter = append(backMatter, ch)
+		default:
+			body = append(body, ch)
+		}
+	}
+
+	// Write front matter
+	for _, ch := range frontMatter {
+		sb.WriteString(b.navEntry(ch))
+	}
+
+	// Write body - handle nested structure (parts containing chapters)
+	b.writeNavBody(&sb, body)
+
+	// Write back matter
+	for _, ch := range backMatter {
+		sb.WriteString(b.navEntry(ch))
+	}
+
+	sb.WriteString(`    </ol>
+  </nav>
+</body>
+</html>
+`)
+
+	return sb.String()
+}
+
+// writeNavBody handles potentially nested body content.
+func (b *Builder) writeNavBody(sb *strings.Builder, chapters []Chapter) {
+	var i int
+	for i < len(chapters) {
+		ch := chapters[i]
+
+		// Parts (level 1) may contain chapters (level 2)
+		if ch.Level == 1 && ch.LevelName == "part" {
+			sb.WriteString(fmt.Sprintf("      <li>\n        <a href=\"chapters/%s.xhtml\">%s</a>\n",
+				ch.ID, escapeXML(b.formatTitle(ch))))
+
+			// Collect nested chapters
+			var nested []Chapter
+			j := i + 1
+			for j < len(chapters) && chapters[j].Level > 1 {
+				nested = append(nested, chapters[j])
+				j++
+			}
+
+			if len(nested) > 0 {
+				sb.WriteString("        <ol>\n")
+				for _, nch := range nested {
+					sb.WriteString("          ")
+					sb.WriteString(b.navEntry(nch))
+				}
+				sb.WriteString("        </ol>\n")
+			}
+
+			sb.WriteString("      </li>\n")
+			i = j
+		} else {
+			sb.WriteString(b.navEntry(ch))
+			i++
+		}
+	}
+}
+
+// navEntry creates a single navigation entry.
+func (b *Builder) navEntry(ch Chapter) string {
+	return fmt.Sprintf("      <li><a href=\"chapters/%s.xhtml\">%s</a></li>\n",
+		ch.ID, escapeXML(b.formatTitle(ch)))
+}
+
+// formatTitle formats a chapter title for display.
+func (b *Builder) formatTitle(ch Chapter) string {
+	// For numbered chapters, include the number
+	if ch.EntryNumber != "" && (ch.LevelName == "chapter" || ch.LevelName == "part") {
+		prefix := ch.LevelName
+		if prefix == "chapter" {
+			prefix = "Chapter"
+		} else if prefix == "part" {
+			prefix = "Part"
+		}
+		// If title is just "Chapter N", don't duplicate
+		if ch.Title == fmt.Sprintf("Chapter %s", ch.EntryNumber) {
+			return ch.Title
+		}
+		if ch.Title == fmt.Sprintf("Part %s", ch.EntryNumber) {
+			return ch.Title
+		}
+		return fmt.Sprintf("%s %s: %s", prefix, ch.EntryNumber, ch.Title)
+	}
+	return ch.Title
+}
+
+// generateNCX creates the toc.ncx for ePub 2 compatibility.
+func (b *Builder) generateNCX() string {
+	var sb strings.Builder
+
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:uid" content="`)
+	sb.WriteString(b.generateUUID())
+	sb.WriteString(`"/>
+    <meta name="dtb:depth" content="2"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+  </head>
+  <docTitle>
+    <text>`)
+	sb.WriteString(escapeXML(b.book.Title))
+	sb.WriteString(`</text>
+  </docTitle>
+  <navMap>
+`)
+
+	// Write nav points
+	for i, ch := range b.chapters {
+		sb.WriteString(fmt.Sprintf("    <navPoint id=\"navpoint-%d\" playOrder=\"%d\">\n", i+1, i+1))
+		sb.WriteString(fmt.Sprintf("      <navLabel><text>%s</text></navLabel>\n", escapeXML(b.formatTitle(ch))))
+		sb.WriteString(fmt.Sprintf("      <content src=\"chapters/%s.xhtml\"/>\n", ch.ID))
+		sb.WriteString("    </navPoint>\n")
+	}
+
+	sb.WriteString(`  </navMap>
+</ncx>
+`)
+
+	return sb.String()
+}

--- a/internal/epub/package.go
+++ b/internal/epub/package.go
@@ -1,0 +1,73 @@
+package epub
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// generatePackage creates the content.opf package document.
+func (b *Builder) generatePackage() string {
+	var sb strings.Builder
+
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="pub-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+`)
+
+	// Dublin Core metadata
+	sb.WriteString(fmt.Sprintf("    <dc:identifier id=\"pub-id\">%s</dc:identifier>\n", b.generateUUID()))
+	sb.WriteString(fmt.Sprintf("    <dc:title>%s</dc:title>\n", escapeXML(b.book.Title)))
+	sb.WriteString(fmt.Sprintf("    <dc:creator>%s</dc:creator>\n", escapeXML(b.book.Author)))
+
+	lang := b.book.Language
+	if lang == "" {
+		lang = "en"
+	}
+	sb.WriteString(fmt.Sprintf("    <dc:language>%s</dc:language>\n", lang))
+
+	if b.book.Publisher != "" {
+		sb.WriteString(fmt.Sprintf("    <dc:publisher>%s</dc:publisher>\n", escapeXML(b.book.Publisher)))
+	}
+
+	// Modified timestamp (required for ePub 3)
+	sb.WriteString(fmt.Sprintf("    <meta property=\"dcterms:modified\">%s</meta>\n",
+		time.Now().UTC().Format("2006-01-02T15:04:05Z")))
+
+	sb.WriteString("  </metadata>\n\n")
+
+	// Manifest
+	sb.WriteString("  <manifest>\n")
+	sb.WriteString("    <item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>\n")
+	sb.WriteString("    <item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/>\n")
+	sb.WriteString("    <item id=\"style\" href=\"styles/style.css\" media-type=\"text/css\"/>\n")
+
+	// Chapter items
+	for _, ch := range b.chapters {
+		sb.WriteString(fmt.Sprintf("    <item id=\"%s\" href=\"chapters/%s.xhtml\" media-type=\"application/xhtml+xml\"/>\n",
+			ch.ID, ch.ID))
+	}
+
+	sb.WriteString("  </manifest>\n\n")
+
+	// Spine (reading order)
+	sb.WriteString("  <spine toc=\"ncx\">\n")
+	for _, ch := range b.chapters {
+		sb.WriteString(fmt.Sprintf("    <itemref idref=\"%s\"/>\n", ch.ID))
+	}
+	sb.WriteString("  </spine>\n")
+
+	sb.WriteString("</package>\n")
+
+	return sb.String()
+}
+
+// escapeXML escapes special XML characters.
+func escapeXML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	return s
+}

--- a/internal/epub/xhtml.go
+++ b/internal/epub/xhtml.go
@@ -1,0 +1,187 @@
+package epub
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// generateChapterXHTML converts a chapter's polished text to XHTML.
+func (b *Builder) generateChapterXHTML(ch Chapter) string {
+	var sb strings.Builder
+
+	// XHTML header
+	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>`)
+	sb.WriteString(escapeXML(ch.Title))
+	sb.WriteString(`</title>
+  <link rel="stylesheet" type="text/css" href="../styles/style.css"/>
+</head>
+<body`)
+
+	// Add class based on matter type
+	switch ch.MatterType {
+	case "front_matter":
+		sb.WriteString(` class="front-matter"`)
+	case "back_matter":
+		sb.WriteString(` class="back-matter"`)
+		if ch.LevelName == "notes" {
+			sb.WriteString(` class="back-matter notes"`)
+		}
+	}
+	sb.WriteString(">\n")
+
+	// Convert markdown to XHTML
+	content := markdownToXHTML(ch.PolishedText, ch)
+	sb.WriteString(content)
+
+	sb.WriteString("\n</body>\n</html>\n")
+
+	return sb.String()
+}
+
+// markdownToXHTML converts markdown-formatted text to XHTML.
+// This is a simple converter that handles the common cases from polished text.
+func markdownToXHTML(md string, ch Chapter) string {
+	if md == "" {
+		return fmt.Sprintf("<h1>%s</h1>\n", escapeXML(ch.Title))
+	}
+
+	lines := strings.Split(md, "\n")
+	var result strings.Builder
+	var inParagraph bool
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Empty line closes paragraph
+		if trimmed == "" {
+			if inParagraph {
+				result.WriteString("</p>\n")
+				inParagraph = false
+			}
+			continue
+		}
+
+		// Headers
+		if strings.HasPrefix(trimmed, "# ") {
+			if inParagraph {
+				result.WriteString("</p>\n")
+				inParagraph = false
+			}
+			result.WriteString("<h1>")
+			result.WriteString(escapeXML(strings.TrimPrefix(trimmed, "# ")))
+			result.WriteString("</h1>\n")
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") {
+			if inParagraph {
+				result.WriteString("</p>\n")
+				inParagraph = false
+			}
+			result.WriteString("<h2>")
+			result.WriteString(escapeXML(strings.TrimPrefix(trimmed, "## ")))
+			result.WriteString("</h2>\n")
+			continue
+		}
+		if strings.HasPrefix(trimmed, "### ") {
+			if inParagraph {
+				result.WriteString("</p>\n")
+				inParagraph = false
+			}
+			result.WriteString("<h3>")
+			result.WriteString(escapeXML(strings.TrimPrefix(trimmed, "### ")))
+			result.WriteString("</h3>\n")
+			continue
+		}
+
+		// Blockquote
+		if strings.HasPrefix(trimmed, "> ") {
+			if inParagraph {
+				result.WriteString("</p>\n")
+				inParagraph = false
+			}
+			result.WriteString("<blockquote><p>")
+			result.WriteString(processInlineFormatting(strings.TrimPrefix(trimmed, "> ")))
+			result.WriteString("</p></blockquote>\n")
+			continue
+		}
+
+		// Horizontal rule
+		if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+			if inParagraph {
+				result.WriteString("</p>\n")
+				inParagraph = false
+			}
+			result.WriteString("<hr/>\n")
+			continue
+		}
+
+		// Regular paragraph text
+		if !inParagraph {
+			result.WriteString("<p>")
+			inParagraph = true
+		} else {
+			// Check if this looks like a new paragraph (starts with capital after sentence end)
+			// or continuation of current paragraph
+			if i > 0 && shouldStartNewParagraph(lines[i-1], trimmed) {
+				result.WriteString("</p>\n<p>")
+			} else {
+				result.WriteString(" ")
+			}
+		}
+		result.WriteString(processInlineFormatting(trimmed))
+	}
+
+	// Close any open paragraph
+	if inParagraph {
+		result.WriteString("</p>\n")
+	}
+
+	return result.String()
+}
+
+// shouldStartNewParagraph determines if a new line should start a new paragraph.
+func shouldStartNewParagraph(prevLine, currentLine string) bool {
+	prevTrimmed := strings.TrimSpace(prevLine)
+	if prevTrimmed == "" {
+		return true
+	}
+	// Previous line ends with sentence-ending punctuation and current starts with capital
+	if len(currentLine) > 0 {
+		lastChar := prevTrimmed[len(prevTrimmed)-1]
+		firstChar := currentLine[0]
+		if (lastChar == '.' || lastChar == '!' || lastChar == '?') &&
+			firstChar >= 'A' && firstChar <= 'Z' {
+			// Could be new paragraph, but often just continuation
+			// Be conservative - only split on double newline (handled elsewhere)
+			return false
+		}
+	}
+	return false
+}
+
+// processInlineFormatting handles bold, italic, and other inline markdown.
+func processInlineFormatting(text string) string {
+	// Escape XML first
+	text = escapeXML(text)
+
+	// Bold: **text** or __text__
+	boldRe := regexp.MustCompile(`\*\*(.+?)\*\*|__(.+?)__`)
+	text = boldRe.ReplaceAllStringFunc(text, func(match string) string {
+		inner := strings.Trim(match, "*_")
+		return "<strong>" + inner + "</strong>"
+	})
+
+	// Italic: *text* or _text_
+	italicRe := regexp.MustCompile(`\*([^*]+)\*|_([^_]+)_`)
+	text = italicRe.ReplaceAllStringFunc(text, func(match string) string {
+		inner := strings.Trim(match, "*_")
+		return "<em>" + inner + "</em>"
+	})
+
+	return text
+}

--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -106,3 +106,8 @@ func (d *Dir) OriginalsDir(bookID string) string {
 func (d *Dir) EnsureOriginalsDir(bookID string) error {
 	return os.MkdirAll(d.OriginalsDir(bookID), 0o755)
 }
+
+// ExportsDir returns the directory for exported files (epub, etc.).
+func (d *Dir) ExportsDir() string {
+	return filepath.Join(d.path, "exports")
+}

--- a/internal/server/endpoints/books_export_epub.go
+++ b/internal/server/endpoints/books_export_epub.go
@@ -1,0 +1,381 @@
+package endpoints
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jackzampolin/shelf/internal/api"
+	"github.com/jackzampolin/shelf/internal/defra"
+	"github.com/jackzampolin/shelf/internal/epub"
+	"github.com/jackzampolin/shelf/internal/svcctx"
+)
+
+// EpubExportResponse is returned when an epub is generated.
+type EpubExportResponse struct {
+	BookID       string `json:"book_id"`
+	Title        string `json:"title"`
+	Author       string `json:"author"`
+	ChapterCount int    `json:"chapter_count"`
+	FilePath     string `json:"file_path"`
+	FileSize     int64  `json:"file_size"`
+	DownloadURL  string `json:"download_url"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// ExportEpubEndpoint handles POST /api/books/{book_id}/export/epub.
+type ExportEpubEndpoint struct{}
+
+func (e *ExportEpubEndpoint) Route() (string, string, http.HandlerFunc) {
+	return "POST", "/api/books/{book_id}/export/epub", e.handler
+}
+
+func (e *ExportEpubEndpoint) RequiresInit() bool { return true }
+
+// handler godoc
+//
+//	@Summary		Export book as ePub
+//	@Description	Generate an ePub 3.0 file from a processed book
+//	@Tags			books,export
+//	@Produce		json
+//	@Param			book_id	path		string	true	"Book ID"
+//	@Success		200		{object}	EpubExportResponse
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		404		{object}	ErrorResponse
+//	@Failure		500		{object}	ErrorResponse
+//	@Router			/api/books/{book_id}/export/epub [post]
+func (e *ExportEpubEndpoint) handler(w http.ResponseWriter, r *http.Request) {
+	bookID := r.PathValue("book_id")
+	if bookID == "" {
+		writeError(w, http.StatusBadRequest, "book_id is required")
+		return
+	}
+
+	if err := defra.ValidateID(bookID); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid book_id: %v", err))
+		return
+	}
+
+	ctx := r.Context()
+	defraClient := svcctx.DefraClientFrom(ctx)
+	if defraClient == nil {
+		writeError(w, http.StatusServiceUnavailable, "defra client not initialized")
+		return
+	}
+
+	homeDir := svcctx.HomeFrom(ctx)
+	if homeDir == nil {
+		writeError(w, http.StatusServiceUnavailable, "home directory not configured")
+		return
+	}
+
+	// Load book metadata
+	bookQuery := fmt.Sprintf(`{
+		Book(filter: {_docID: {_eq: "%s"}}) {
+			_docID
+			title
+			author
+			page_count
+			status
+		}
+	}`, bookID)
+
+	bookResp, err := defraClient.Execute(ctx, bookQuery, nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to query book: %v", err))
+		return
+	}
+
+	books, ok := bookResp.Data["Book"].([]any)
+	if !ok || len(books) == 0 {
+		writeError(w, http.StatusNotFound, "book not found")
+		return
+	}
+
+	bookData, ok := books[0].(map[string]any)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "invalid book data")
+		return
+	}
+
+	// Check book status
+	status, _ := bookData["status"].(string)
+	if status != "complete" && status != "processing" {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("book is not ready for export (status: %s)", status))
+		return
+	}
+
+	// Load chapters
+	chapterQuery := fmt.Sprintf(`{
+		Chapter(filter: {book_id: {_eq: "%s"}}) {
+			_docID
+			entry_id
+			title
+			level
+			level_name
+			entry_number
+			matter_type
+			polished_text
+			sort_order
+			polish_complete
+		}
+	}`, bookID)
+
+	chapterResp, err := defraClient.Execute(ctx, chapterQuery, nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to query chapters: %v", err))
+		return
+	}
+
+	chapterList, ok := chapterResp.Data["Chapter"].([]any)
+	if !ok || len(chapterList) == 0 {
+		writeError(w, http.StatusBadRequest, "no chapters found - book processing may not be complete")
+		return
+	}
+
+	// Convert to epub.Chapter
+	var chapters []epub.Chapter
+	for _, ch := range chapterList {
+		chData, ok := ch.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Skip chapters without polished text
+		polishComplete, _ := chData["polish_complete"].(bool)
+		if !polishComplete {
+			continue
+		}
+
+		chapter := epub.Chapter{
+			ID:           getString(chData, "entry_id"),
+			Title:        getString(chData, "title"),
+			Level:        getInt(chData, "level"),
+			LevelName:    getString(chData, "level_name"),
+			EntryNumber:  getString(chData, "entry_number"),
+			MatterType:   getString(chData, "matter_type"),
+			PolishedText: getString(chData, "polished_text"),
+			SortOrder:    getInt(chData, "sort_order"),
+		}
+		chapters = append(chapters, chapter)
+	}
+
+	if len(chapters) == 0 {
+		writeError(w, http.StatusBadRequest, "no chapters with polished text found")
+		return
+	}
+
+	// Sort by sort_order
+	sortChapters(chapters)
+
+	// Build epub
+	book := epub.Book{
+		ID:       bookID,
+		Title:    getString(bookData, "title"),
+		Author:   getString(bookData, "author"),
+		Language: "en",
+	}
+
+	builder := epub.NewBuilder(book, chapters)
+
+	// Create export directory
+	exportDir := filepath.Join(homeDir.ExportsDir(), bookID)
+	if err := os.MkdirAll(exportDir, 0755); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to create export directory: %v", err))
+		return
+	}
+
+	// Generate filename
+	safeTitle := sanitizeFilename(book.Title)
+	if safeTitle == "" {
+		safeTitle = "book"
+	}
+	filename := fmt.Sprintf("%s.epub", safeTitle)
+	outputPath := filepath.Join(exportDir, filename)
+
+	// Build epub
+	if err := builder.Build(outputPath); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to generate epub: %v", err))
+		return
+	}
+
+	// Get file info
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to stat epub file: %v", err))
+		return
+	}
+
+	resp := EpubExportResponse{
+		BookID:       bookID,
+		Title:        book.Title,
+		Author:       book.Author,
+		ChapterCount: len(chapters),
+		FilePath:     outputPath,
+		FileSize:     info.Size(),
+		DownloadURL:  fmt.Sprintf("/api/books/%s/export/epub/download", bookID),
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (e *ExportEpubEndpoint) Command(getServerURL func() string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "export-epub <book_id>",
+		Short: "Export book as ePub",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			bookID := args[0]
+
+			client := api.NewClient(getServerURL())
+			var resp EpubExportResponse
+			if err := client.Post(ctx, fmt.Sprintf("/api/books/%s/export/epub", bookID), nil, &resp); err != nil {
+				return err
+			}
+
+			return api.Output(resp)
+		},
+	}
+}
+
+// DownloadEpubEndpoint handles GET /api/books/{book_id}/export/epub/download.
+type DownloadEpubEndpoint struct{}
+
+func (e *DownloadEpubEndpoint) Route() (string, string, http.HandlerFunc) {
+	return "GET", "/api/books/{book_id}/export/epub/download", e.handler
+}
+
+func (e *DownloadEpubEndpoint) RequiresInit() bool { return true }
+
+// handler godoc
+//
+//	@Summary		Download ePub file
+//	@Description	Download the generated ePub file for a book
+//	@Tags			books,export
+//	@Produce		application/epub+zip
+//	@Param			book_id	path		string	true	"Book ID"
+//	@Success		200		{file}		file
+//	@Failure		400		{object}	ErrorResponse
+//	@Failure		404		{object}	ErrorResponse
+//	@Router			/api/books/{book_id}/export/epub/download [get]
+func (e *DownloadEpubEndpoint) handler(w http.ResponseWriter, r *http.Request) {
+	bookID := r.PathValue("book_id")
+	if bookID == "" {
+		writeError(w, http.StatusBadRequest, "book_id is required")
+		return
+	}
+
+	if err := defra.ValidateID(bookID); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid book_id: %v", err))
+		return
+	}
+
+	ctx := r.Context()
+	homeDir := svcctx.HomeFrom(ctx)
+	if homeDir == nil {
+		writeError(w, http.StatusServiceUnavailable, "home directory not configured")
+		return
+	}
+
+	// Find epub file in export directory
+	exportDir := filepath.Join(homeDir.ExportsDir(), bookID)
+	entries, err := os.ReadDir(exportDir)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "no epub export found - run export first")
+		return
+	}
+
+	var epubPath string
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".epub") {
+			epubPath = filepath.Join(exportDir, entry.Name())
+			break
+		}
+	}
+
+	if epubPath == "" {
+		writeError(w, http.StatusNotFound, "no epub file found")
+		return
+	}
+
+	// Serve the file
+	filename := filepath.Base(epubPath)
+	w.Header().Set("Content-Type", "application/epub+zip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	http.ServeFile(w, r, epubPath)
+}
+
+func (e *DownloadEpubEndpoint) Command(getServerURL func() string) *cobra.Command {
+	var outputPath string
+	cmd := &cobra.Command{
+		Use:   "download-epub <book_id>",
+		Short: "Download ePub file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			bookID := args[0]
+
+			client := api.NewClient(getServerURL())
+			data, err := client.GetRaw(ctx, fmt.Sprintf("/api/books/%s/export/epub/download", bookID))
+			if err != nil {
+				return err
+			}
+
+			if outputPath == "" {
+				outputPath = fmt.Sprintf("%s.epub", bookID)
+			}
+
+			if err := os.WriteFile(outputPath, data, 0644); err != nil {
+				return fmt.Errorf("failed to write file: %w", err)
+			}
+
+			fmt.Printf("Downloaded to: %s\n", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Output file path")
+	return cmd
+}
+
+// Helper functions
+
+func sortChapters(chapters []epub.Chapter) {
+	// Simple bubble sort by sort_order
+	for i := 0; i < len(chapters)-1; i++ {
+		for j := 0; j < len(chapters)-i-1; j++ {
+			if chapters[j].SortOrder > chapters[j+1].SortOrder {
+				chapters[j], chapters[j+1] = chapters[j+1], chapters[j]
+			}
+		}
+	}
+}
+
+func sanitizeFilename(name string) string {
+	// Remove or replace problematic characters
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+	)
+	name = replacer.Replace(name)
+	// Trim spaces and dots from ends
+	name = strings.Trim(name, " .")
+	// Limit length
+	if len(name) > 100 {
+		name = name[:100]
+	}
+	return name
+}

--- a/internal/server/endpoints/registry.go
+++ b/internal/server/endpoints/registry.go
@@ -35,6 +35,10 @@ func All(cfg Config) []api.Endpoint {
 		&GetBookChaptersEndpoint{},
 		&RerunTocEndpoint{},
 
+		// Export endpoints
+		&ExportEpubEndpoint{},
+		&DownloadEpubEndpoint{},
+
 		// Page endpoints
 		&PageImageEndpoint{},
 		&ListPagesEndpoint{},

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shelf-web",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.9",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.92.0",
         "openapi-fetch": "^0.13.0",
@@ -104,6 +105,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -475,6 +477,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -498,6 +501,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1108,6 +1112,79 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
+      "integrity": "sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1254,6 +1331,103 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.3.tgz",
+      "integrity": "sha512-FsquWvjSCwC2/sBk4b+OqJyONETUIXQ2vM0YdPAuC+QFQh2DT6TIBo6dOZVSezlhudDla69xFBd6JvCFq1AbUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.26.0",
+        "@react-aria/utils": "^3.32.0",
+        "@react-types/shared": "^3.32.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.26.0.tgz",
+      "integrity": "sha512-AAEcHiltjfbmP1i9iaVw34Mb7kbkiHpYdqieWufldh4aplWgsF11YQZOfaCJW4QoR2ML4Zzoa9nfFwLXA52R7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.32.0",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.32.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.32.0.tgz",
+      "integrity": "sha512-/7Rud06+HVBIlTwmwmJa2W8xVtgxgzm0+kLbuFooZRzKDON6hhozS1dOMR/YLMxyJOaYOTpImcP4vRR9gL1hEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.32.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.1.tgz",
+      "integrity": "sha512-famxyD5emrGGpFuUlgOP6fVW2h/ZaF405G5KDi3zPHzyjAWys/8W6NAVJtNbkCkhedmvL0xOhvt8feGXyXaw5w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/@redocly/ajv": {
       "version": "8.17.1",
@@ -1646,6 +1820,15 @@
         "win32"
       ]
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tanstack/history": {
       "version": "1.141.0",
       "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.141.0.tgz",
@@ -1690,6 +1873,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.144.0.tgz",
       "integrity": "sha512-GmRyIGmHtGj3VLTHXepIwXAxTcHyL5W7Vw7O1CnVEtFxQQWKMVOnWgI7tPY6FhlNwMKVb3n0mPFWz9KMYyd2GA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.141.0",
         "@tanstack/react-store": "^0.8.0",
@@ -1756,11 +1940,29 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
+      "integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/router-core": {
       "version": "1.144.0",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.144.0.tgz",
       "integrity": "sha512-6oVERtK9XDHCP4XojgHsdHO56ZSj11YaWjF5g/zw39LhyA6Lx+/X86AEIHO4y0BUrMQaJfcjdAQMVSAs6Vjtdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.141.0",
         "@tanstack/store": "^0.8.0",
@@ -1948,6 +2150,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
+      "integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/virtual-file-routes": {
       "version": "1.141.0",
       "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.141.0.tgz",
@@ -2027,6 +2239,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2044,6 +2257,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2104,6 +2318,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -2484,6 +2699,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2763,6 +2979,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2944,7 +3161,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3074,7 +3290,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3342,6 +3559,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4144,6 +4362,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4183,6 +4402,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -4971,6 +5191,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5133,6 +5354,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5145,6 +5367,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5412,6 +5635,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.2.tgz",
       "integrity": "sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5539,7 +5763,6 @@
       "integrity": "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.3.0",
@@ -5563,7 +5786,6 @@
       "integrity": "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5738,6 +5960,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -5924,6 +6152,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6054,7 +6283,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -6109,6 +6337,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6240,6 +6469,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7337,6 +7567,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7350,6 +7581,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -7880,6 +8112,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -8118,24 +8351,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",

--- a/web/src/components/book/tabs/OverviewTab.tsx
+++ b/web/src/components/book/tabs/OverviewTab.tsx
@@ -1,0 +1,206 @@
+import { Link } from '@tanstack/react-router'
+import { useBookCost, useDetailedStatus, useChapters, type BookData } from './useBookData'
+
+interface OverviewTabProps {
+  bookId: string
+  book: BookData
+}
+
+export function OverviewTab({ bookId, book }: OverviewTabProps) {
+  const { data: cost } = useBookCost(bookId)
+  const { data: detailedStatus } = useDetailedStatus(bookId)
+  const { data: chaptersData } = useChapters(bookId, book.status === 'complete')
+
+  const chapters = chaptersData?.chapters || []
+  const hasChapters = chapters.length > 0
+
+  // Calculate stats
+  const frontMatter = chapters.filter((c: { matter_type?: string }) => c.matter_type === 'front_matter').length
+  const bodyChapters = chapters.filter((c: { matter_type?: string }) => c.matter_type === 'body').length
+  const backMatter = chapters.filter((c: { matter_type?: string }) => c.matter_type === 'back_matter').length
+
+  // Determine processing stage
+  const getProcessingStage = () => {
+    if (!detailedStatus) return null
+    if (detailedStatus.structure?.complete) return 'Complete'
+    if (detailedStatus.structure?.started) return 'Building Structure'
+    if (detailedStatus.toc?.finalize_started) return 'Finalizing ToC'
+    if (detailedStatus.toc?.link_started) return 'Linking ToC'
+    if (detailedStatus.toc?.extract_started) return 'Extracting ToC'
+    if (detailedStatus.toc?.finder_started) return 'Finding ToC'
+    if (detailedStatus.stages?.label?.complete) return 'Labeling Complete'
+    if (detailedStatus.stages?.blend?.complete) return 'Blending Complete'
+    if (detailedStatus.stages?.ocr?.complete) return 'OCR Complete'
+    return 'Processing'
+  }
+
+  const processingStage = getProcessingStage()
+
+  return (
+    <div className="space-y-6">
+      {/* Quick Stats Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard label="Pages" value={book.page_count || 0} />
+        <StatCard
+          label="Status"
+          value={
+            <span
+              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium ${
+                book.status === 'complete'
+                  ? 'bg-green-100 text-green-800'
+                  : book.status === 'processing'
+                    ? 'bg-blue-100 text-blue-800'
+                    : book.status === 'error'
+                      ? 'bg-red-100 text-red-800'
+                      : 'bg-gray-100 text-gray-800'
+              }`}
+            >
+              {book.status || 'pending'}
+            </span>
+          }
+        />
+        <StatCard
+          label="Total Cost"
+          value={cost?.total_cost_usd !== undefined ? `$${cost.total_cost_usd.toFixed(4)}` : '--'}
+          mono
+        />
+        <StatCard label="Chapters" value={hasChapters ? chapters.length : '--'} />
+      </div>
+
+      {/* Processing Status (only show if not complete) */}
+      {book.status !== 'complete' && processingStage && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className="animate-pulse">
+                <div className="h-3 w-3 bg-blue-500 rounded-full" />
+              </div>
+              <div>
+                <div className="font-medium text-blue-900">Processing in Progress</div>
+                <div className="text-sm text-blue-700">{processingStage}</div>
+              </div>
+            </div>
+            <Link
+              to="/books/$bookId"
+              params={{ bookId }}
+              search={{ tab: 'processing' }}
+              className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+            >
+              View Details →
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {/* Book Structure Summary (if complete) */}
+      {hasChapters && (
+        <div className="bg-white border rounded-lg p-6">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">Book Structure</h3>
+          <div className="grid grid-cols-3 gap-6">
+            <StructureStat label="Front Matter" count={frontMatter} color="purple" />
+            <StructureStat label="Body" count={bodyChapters} color="blue" />
+            <StructureStat label="Back Matter" count={backMatter} color="orange" />
+          </div>
+          <div className="mt-4 pt-4 border-t">
+            <Link
+              to="/books/$bookId/chapters"
+              params={{ bookId }}
+              className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+            >
+              View All Chapters →
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {/* Cost Breakdown (if available) */}
+      {cost?.breakdown && Object.keys(cost.breakdown).length > 0 && (
+        <div className="bg-white border rounded-lg p-6">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">Cost Breakdown</h3>
+          <div className="space-y-2">
+            {Object.entries(cost.breakdown)
+              .sort(([, a], [, b]) => (b as number) - (a as number))
+              .map(([stage, amount]) => (
+                <div key={stage} className="flex justify-between text-sm">
+                  <span className="text-gray-600 capitalize">{stage.replace(/_/g, ' ')}</span>
+                  <span className="font-mono text-gray-900">${(amount as number).toFixed(4)}</span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* Quick Actions */}
+      <div className="bg-gray-50 border rounded-lg p-6">
+        <h3 className="text-lg font-medium text-gray-900 mb-4">Quick Actions</h3>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            to="/books/$bookId/pages/$pageNum"
+            params={{ bookId, pageNum: '1' }}
+            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+          >
+            Browse Pages
+          </Link>
+          <Link
+            to="/books/$bookId/pages-table"
+            params={{ bookId }}
+            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+          >
+            Pages Table
+          </Link>
+          {hasChapters && (
+            <Link
+              to="/books/$bookId/chapters"
+              params={{ bookId }}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+            >
+              Read Chapters
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="bg-white border rounded-lg p-4">
+      <div className="text-sm font-medium text-gray-500">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold ${mono ? 'font-mono' : ''}`}>{value}</div>
+    </div>
+  )
+}
+
+function StructureStat({
+  label,
+  count,
+  color,
+}: {
+  label: string
+  count: number
+  color: 'purple' | 'blue' | 'orange'
+}) {
+  const colors = {
+    purple: 'bg-purple-100 text-purple-800',
+    blue: 'bg-blue-100 text-blue-800',
+    orange: 'bg-orange-100 text-orange-800',
+  }
+
+  return (
+    <div className="text-center">
+      <div className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${colors[color]}`}>
+        {label}
+      </div>
+      <div className="mt-2 text-3xl font-bold text-gray-900">{count}</div>
+    </div>
+  )
+}

--- a/web/src/components/book/tabs/ProcessingTab.tsx
+++ b/web/src/components/book/tabs/ProcessingTab.tsx
@@ -1,0 +1,326 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
+import { useNavigate } from '@tanstack/react-router'
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
+import { client, unwrap } from '@/api/client'
+import { ProgressBar } from '@/components/ui'
+import {
+  CollapsibleSection,
+  TocSection,
+  StructureSection,
+  PatternAnalysisSection,
+  AgentLogModal,
+  MetadataModal,
+  JobHistorySection,
+} from '@/components/book'
+import { useDetailedStatus, useDetailedMetrics, type BookData } from './useBookData'
+
+interface ProcessingTabProps {
+  bookId: string
+  book: BookData
+}
+
+const JOB_TYPES = [
+  { id: 'process-book', label: 'Full Pipeline', description: 'OCR → Blend → Pattern Analysis → Label → ToC → Structure', force: false },
+  { id: 'ocr-book', label: 'OCR + Blend Only', description: 'OCR and blend all pages', force: false },
+  { id: 'label-book', label: 'Label Only', description: 'Label pages (requires pattern analysis)', force: false },
+  { id: 'metadata-book', label: 'Metadata Only', description: 'Extract book metadata', force: false },
+  { id: 'toc-book', label: 'ToC Only', description: 'Find and extract table of contents', force: false },
+  { id: 'link-toc', label: 'Link ToC Only', description: 'Link ToC entries to actual pages', force: false },
+  { id: 'link-toc', label: 'Link ToC (Force)', description: 'Re-link ToC entries', force: true },
+]
+
+interface AgentLogDetail {
+  agent_type?: string
+  iterations?: number
+  success?: boolean
+  started_at?: string
+  error?: string
+  result?: unknown
+  messages?: unknown
+  tool_calls?: unknown
+}
+
+export function ProcessingTab({ bookId, book }: ProcessingTabProps) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [metadataModalOpen, setMetadataModalOpen] = useState(false)
+  const [agentLogModalOpen, setAgentLogModalOpen] = useState(false)
+  const [selectedAgentLogId, setSelectedAgentLogId] = useState<string | null>(null)
+
+  const { data: detailedStatus } = useDetailedStatus(bookId)
+  const { data: detailedMetrics } = useDetailedMetrics(bookId)
+
+  const { data: agentLogDetail } = useQuery({
+    queryKey: ['agent-logs', selectedAgentLogId],
+    queryFn: async () =>
+      selectedAgentLogId
+        ? (unwrap(
+            await client.GET('/api/agent-logs/{id}', {
+              params: { path: { id: selectedAgentLogId } },
+            })
+          ) as AgentLogDetail)
+        : null,
+    enabled: !!selectedAgentLogId,
+  })
+
+  const startJobMutation = useMutation({
+    mutationFn: async (params: { jobType?: string; force?: boolean }) => {
+      const { jobType, force } = params
+      const result = await client.POST('/api/jobs/start/{book_id}', {
+        params: { path: { book_id: bookId } },
+        body: { job_type: jobType || 'process-book', force: force || false },
+      })
+      return unwrap(result)
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['jobs', 'status', bookId] })
+      queryClient.invalidateQueries({ queryKey: ['books', bookId] })
+      if (data?.job_id) {
+        navigate({ to: '/jobs/$jobId', params: { jobId: data.job_id } })
+      }
+    },
+  })
+
+  const handleViewAgentLog = (id: string) => {
+    setSelectedAgentLogId(id)
+    setAgentLogModalOpen(true)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Actions Header */}
+      <div className="bg-white border rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-medium text-gray-900">Processing Actions</h3>
+            <p className="text-sm text-gray-500">Start or restart processing jobs for this book</p>
+          </div>
+          {book.status !== 'error' && (
+            <div className="flex items-center">
+              <button
+                onClick={() => startJobMutation.mutate({ jobType: 'process-book' })}
+                disabled={startJobMutation.isPending}
+                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-l-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {startJobMutation.isPending ? 'Starting...' : 'Start Full Pipeline'}
+              </button>
+              <Menu as="div" className="relative">
+                <MenuButton
+                  disabled={startJobMutation.isPending}
+                  className="inline-flex items-center px-2 py-2 border border-transparent text-sm font-medium rounded-r-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed border-l border-blue-500"
+                >
+                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <path
+                      fillRule="evenodd"
+                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </MenuButton>
+                <MenuItems className="absolute right-0 z-10 mt-2 w-64 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+                  <div className="py-1">
+                    {JOB_TYPES.map((job, index) => (
+                      <MenuItem key={`${job.id}-${index}`}>
+                        {({ active }) => (
+                          <button
+                            onClick={() => startJobMutation.mutate({ jobType: job.id, force: job.force })}
+                            className={`${
+                              active ? 'bg-gray-100 text-gray-900' : 'text-gray-700'
+                            } block w-full text-left px-4 py-2 text-sm`}
+                          >
+                            <div className="font-medium">{job.label}</div>
+                            <div className="text-xs text-gray-500">{job.description}</div>
+                          </button>
+                        )}
+                      </MenuItem>
+                    ))}
+                  </div>
+                </MenuItems>
+              </Menu>
+            </div>
+          )}
+        </div>
+        {startJobMutation.isError && (
+          <p className="text-sm text-red-600 mt-2">
+            Error: {startJobMutation.error?.message || 'Failed to start job'}
+          </p>
+        )}
+      </div>
+
+      {/* Processing Pipeline */}
+      {detailedStatus && (
+        <div className="bg-white border rounded-lg p-6">
+          <h3 className="text-lg font-medium text-gray-900 mb-4">Pipeline Status</h3>
+          <div className="space-y-4">
+            {/* OCR Section */}
+            {detailedStatus.ocr_progress && Object.entries(detailedStatus.ocr_progress).length > 0 ? (
+              Object.entries(detailedStatus.ocr_progress).map(([provider, progress]) => (
+                <CollapsibleSection
+                  key={provider}
+                  title={`OCR: ${provider}`}
+                  current={progress.complete || 0}
+                  total={progress.total || 0}
+                  cost={progress.cost_usd}
+                  metrics={detailedMetrics?.stages?.[`ocr:${provider}`]}
+                  stageType="ocr"
+                >
+                  <div className="pl-4 border-l-2 border-gray-200">
+                    <ProgressBar label="Pages" current={progress.complete || 0} total={progress.total || 0} />
+                  </div>
+                </CollapsibleSection>
+              ))
+            ) : (
+              <CollapsibleSection
+                title="OCR"
+                current={detailedStatus.stages?.ocr?.complete || 0}
+                total={detailedStatus.stages?.ocr?.total || 0}
+                cost={detailedStatus.stages?.ocr?.total_cost_usd}
+                stageType="ocr"
+              >
+                <p className="text-sm text-gray-400 pl-4">No OCR results yet</p>
+              </CollapsibleSection>
+            )}
+
+            {/* Blend Section */}
+            <CollapsibleSection
+              title="Blend"
+              current={detailedStatus.stages?.blend?.complete || 0}
+              total={detailedStatus.stages?.blend?.total || 0}
+              cost={detailedStatus.stages?.blend?.cost_usd}
+              metrics={detailedMetrics?.stages?.['blend']}
+              stageType="blend"
+            >
+              <div className="pl-4 border-l-2 border-gray-200">
+                <ProgressBar
+                  label="Pages"
+                  current={detailedStatus.stages?.blend?.complete || 0}
+                  total={detailedStatus.stages?.blend?.total || 0}
+                />
+              </div>
+            </CollapsibleSection>
+
+            {/* Pattern Analysis Section */}
+            <PatternAnalysisSection
+              patternAnalysisJSON={book?.page_pattern_analysis_json}
+              complete={detailedStatus.stages?.pattern_analysis?.complete}
+              cost={detailedStatus.stages?.pattern_analysis?.cost_usd}
+              metrics={detailedMetrics?.stages?.['pattern_analysis']}
+            />
+
+            {/* Label Section */}
+            <CollapsibleSection
+              title="Label"
+              current={detailedStatus.stages?.label?.complete || 0}
+              total={detailedStatus.stages?.label?.total || 0}
+              cost={detailedStatus.stages?.label?.cost_usd}
+              metrics={detailedMetrics?.stages?.['label']}
+            >
+              <div className="pl-4 border-l-2 border-gray-200">
+                <ProgressBar
+                  label="Pages"
+                  current={detailedStatus.stages?.label?.complete || 0}
+                  total={detailedStatus.stages?.label?.total || 0}
+                />
+              </div>
+            </CollapsibleSection>
+
+            {/* Metadata Section */}
+            <div className="border-t pt-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <span className="text-sm font-medium text-gray-700">Metadata</span>
+                  <StatusIndicator
+                    status={
+                      detailedStatus.metadata?.complete
+                        ? 'complete'
+                        : detailedStatus.metadata?.failed
+                          ? 'failed'
+                          : detailedStatus.metadata?.started
+                            ? 'in_progress'
+                            : 'pending'
+                    }
+                  />
+                </div>
+                <div className="flex items-center space-x-2">
+                  {detailedStatus.metadata?.cost_usd !== undefined && (
+                    <span className="font-mono text-sm text-gray-500">
+                      ${detailedStatus.metadata.cost_usd.toFixed(4)}
+                    </span>
+                  )}
+                  {detailedStatus.metadata?.complete && detailedStatus.metadata?.data && (
+                    <button
+                      onClick={() => setMetadataModalOpen(true)}
+                      className="text-sm text-blue-600 hover:text-blue-800"
+                    >
+                      View Details
+                    </button>
+                  )}
+                </div>
+              </div>
+              {detailedStatus.metadata?.complete && detailedStatus.metadata?.data && (
+                <div className="mt-2 pl-4 text-sm text-gray-600">
+                  <div>Title: {detailedStatus.metadata.data.title || '-'}</div>
+                  <div>Author: {detailedStatus.metadata.data.author || '-'}</div>
+                </div>
+              )}
+            </div>
+
+            {/* ToC Section */}
+            <TocSection
+              toc={detailedStatus.toc}
+              bookId={bookId}
+              metrics={detailedMetrics?.stages}
+              onViewAgentLog={handleViewAgentLog}
+            />
+
+            {/* Structure Section */}
+            <StructureSection structure={detailedStatus.structure} bookId={bookId} metrics={detailedMetrics?.stages} />
+          </div>
+        </div>
+      )}
+
+      {/* Job History */}
+      <JobHistorySection bookId={bookId} />
+
+      {/* Metadata Modal */}
+      {metadataModalOpen && detailedStatus?.metadata?.data && (
+        <MetadataModal data={detailedStatus.metadata.data} onClose={() => setMetadataModalOpen(false)} />
+      )}
+
+      {/* Agent Log Modal */}
+      {agentLogModalOpen && (
+        <AgentLogModal
+          detail={agentLogDetail || null}
+          onClose={() => {
+            setAgentLogModalOpen(false)
+            setSelectedAgentLogId(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function StatusIndicator({ status }: { status: 'pending' | 'in_progress' | 'complete' | 'failed' }) {
+  const styles = {
+    pending: 'bg-gray-100 text-gray-500',
+    in_progress: 'bg-blue-100 text-blue-700',
+    complete: 'bg-green-100 text-green-700',
+    failed: 'bg-red-100 text-red-700',
+  }
+
+  const icons = {
+    pending: '○',
+    in_progress: '◐',
+    complete: '●',
+    failed: '✕',
+  }
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${styles[status]}`}>
+      <span className="mr-1">{icons[status]}</span>
+      {status.replace('_', ' ')}
+    </span>
+  )
+}

--- a/web/src/components/book/tabs/ReadTab.tsx
+++ b/web/src/components/book/tabs/ReadTab.tsx
@@ -1,0 +1,279 @@
+import { useState, useMemo } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useChapters, type BookData } from './useBookData'
+
+interface ReadTabProps {
+  bookId: string
+  book: BookData
+}
+
+interface Chapter {
+  id: string
+  title: string
+  level: number
+  level_name?: string
+  entry_number?: string
+  start_page: number
+  end_page: number
+  matter_type: string
+  sort_order: number
+  word_count?: number
+  page_count: number
+  polish_complete?: boolean
+  polish_failed?: boolean
+  polished_text?: string
+}
+
+export function ReadTab({ bookId, book: _book }: ReadTabProps) {
+  const { data: chaptersData, isLoading } = useChapters(bookId)
+  const [expandedChapter, setExpandedChapter] = useState<string | null>(null)
+  const [matterFilter, setMatterFilter] = useState<string>('all')
+
+  const chapters = chaptersData?.chapters || []
+  const hasChapters = chaptersData?.has_chapters
+
+  // Sort chapters by sort_order
+  const sortedChapters = useMemo(() => {
+    let filtered = [...chapters]
+    if (matterFilter !== 'all') {
+      filtered = filtered.filter((c: Chapter) => c.matter_type === matterFilter)
+    }
+    return filtered.sort((a: Chapter, b: Chapter) => a.sort_order - b.sort_order)
+  }, [chapters, matterFilter])
+
+  // Group chapters by matter type for stats
+  const matterCounts = useMemo(() => {
+    return chapters.reduce(
+      (acc: Record<string, number>, c: Chapter) => {
+        const matter = c.matter_type || 'unknown'
+        acc[matter] = (acc[matter] || 0) + 1
+        return acc
+      },
+      {} as Record<string, number>
+    )
+  }, [chapters])
+
+  if (isLoading) {
+    return (
+      <div className="text-center py-12">
+        <div className="text-gray-500">Loading chapters...</div>
+      </div>
+    )
+  }
+
+  if (!hasChapters) {
+    return (
+      <div className="bg-white border rounded-lg p-12 text-center">
+        <div className="text-gray-400 text-5xl mb-4">📖</div>
+        <h3 className="text-lg font-medium text-gray-900 mb-2">No Chapters Available</h3>
+        <p className="text-gray-500 mb-4">
+          Chapters are generated after the table of contents is extracted and linked.
+        </p>
+        <Link
+          to="/books/$bookId/pages/$pageNum"
+          params={{ bookId, pageNum: '1' }}
+          className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+        >
+          Browse Pages Instead
+        </Link>
+      </div>
+    )
+  }
+
+  const matterColors: Record<string, string> = {
+    front_matter: 'bg-purple-100 text-purple-800 border-purple-200',
+    body: 'bg-blue-100 text-blue-800 border-blue-200',
+    back_matter: 'bg-orange-100 text-orange-800 border-orange-200',
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter Bar */}
+      <div className="flex items-center justify-between bg-white border rounded-lg p-3">
+        <div className="flex items-center space-x-2">
+          <span className="text-sm text-gray-500">Filter:</span>
+          <button
+            onClick={() => setMatterFilter('all')}
+            className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+              matterFilter === 'all'
+                ? 'bg-gray-900 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            All ({chapters.length})
+          </button>
+          {matterCounts.front_matter > 0 && (
+            <button
+              onClick={() => setMatterFilter('front_matter')}
+              className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                matterFilter === 'front_matter'
+                  ? 'bg-purple-600 text-white'
+                  : 'bg-purple-100 text-purple-700 hover:bg-purple-200'
+              }`}
+            >
+              Front ({matterCounts.front_matter})
+            </button>
+          )}
+          {matterCounts.body > 0 && (
+            <button
+              onClick={() => setMatterFilter('body')}
+              className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                matterFilter === 'body'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-blue-100 text-blue-700 hover:bg-blue-200'
+              }`}
+            >
+              Body ({matterCounts.body})
+            </button>
+          )}
+          {matterCounts.back_matter > 0 && (
+            <button
+              onClick={() => setMatterFilter('back_matter')}
+              className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                matterFilter === 'back_matter'
+                  ? 'bg-orange-600 text-white'
+                  : 'bg-orange-100 text-orange-700 hover:bg-orange-200'
+              }`}
+            >
+              Back ({matterCounts.back_matter})
+            </button>
+          )}
+        </div>
+        <div className="text-sm text-gray-500">
+          {sortedChapters.length} {sortedChapters.length === 1 ? 'chapter' : 'chapters'}
+        </div>
+      </div>
+
+      {/* Chapters List */}
+      <div className="bg-white border rounded-lg divide-y">
+        {sortedChapters.map((chapter: Chapter) => (
+          <ChapterCard
+            key={chapter.id}
+            chapter={chapter}
+            bookId={bookId}
+            isExpanded={expandedChapter === chapter.id}
+            onToggle={() => setExpandedChapter(expandedChapter === chapter.id ? null : chapter.id)}
+            matterColors={matterColors}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface ChapterCardProps {
+  chapter: Chapter
+  bookId: string
+  isExpanded: boolean
+  onToggle: () => void
+  matterColors: Record<string, string>
+}
+
+function ChapterCard({ chapter, bookId, isExpanded, onToggle, matterColors }: ChapterCardProps) {
+  const hasPolishedText = !!chapter.polished_text
+  const indent = chapter.level * 16
+
+  return (
+    <div className="group">
+      {/* Chapter Header */}
+      <button
+        onClick={onToggle}
+        className="w-full px-4 py-4 flex items-start justify-between text-left hover:bg-gray-50 transition-colors"
+      >
+        <div className="flex items-start space-x-3 flex-1 min-w-0" style={{ paddingLeft: indent }}>
+          {/* Expand indicator */}
+          <span
+            className={`text-gray-400 transition-transform mt-1 ${isExpanded ? 'rotate-90' : ''} ${
+              hasPolishedText ? '' : 'opacity-30'
+            }`}
+          >
+            ▶
+          </span>
+
+          <div className="flex-1 min-w-0">
+            {/* Title row */}
+            <div className="flex items-center space-x-2">
+              {chapter.entry_number && (
+                <span className="text-gray-400 font-mono text-sm">{chapter.entry_number}.</span>
+              )}
+              <span className={`font-medium ${chapter.level <= 1 ? 'text-lg' : ''}`}>
+                {chapter.title || `(${chapter.level_name || 'Untitled'})`}
+              </span>
+              {chapter.level_name && chapter.title && (
+                <span className="text-xs text-gray-400">({chapter.level_name})</span>
+              )}
+            </div>
+
+            {/* Meta row */}
+            <div className="flex items-center space-x-3 mt-1 text-sm text-gray-500">
+              <span>
+                Pages {chapter.start_page}–{chapter.end_page}
+              </span>
+              {chapter.word_count && chapter.word_count > 0 && (
+                <span>{chapter.word_count.toLocaleString()} words</span>
+              )}
+              {!hasPolishedText && (
+                <span className="text-amber-600 text-xs">(text not ready)</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Right side: matter type badge and link */}
+        <div className="flex items-center space-x-3 ml-4">
+          <span
+            className={`px-2 py-1 rounded text-xs font-medium border ${
+              matterColors[chapter.matter_type] || 'bg-gray-100 text-gray-600 border-gray-200'
+            }`}
+          >
+            {chapter.matter_type?.replace('_', ' ') || 'unknown'}
+          </span>
+          <Link
+            to="/books/$bookId/pages/$pageNum"
+            params={{ bookId, pageNum: String(chapter.start_page) }}
+            onClick={(e) => e.stopPropagation()}
+            className="text-blue-600 hover:text-blue-800 text-sm opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            View →
+          </Link>
+        </div>
+      </button>
+
+      {/* Expanded Content */}
+      {isExpanded && (
+        <div className="px-4 pb-4" style={{ paddingLeft: indent + 16 + 12 }}>
+          <div className="bg-gray-50 rounded-lg p-4 border-l-4 border-gray-300">
+            {hasPolishedText ? (
+              <div className="prose prose-sm max-w-none text-gray-700 leading-relaxed max-h-[32rem] overflow-y-auto">
+                {chapter.polished_text!.split('\n\n').map((para, idx) => (
+                  <p key={idx} className="mb-3">
+                    {para}
+                  </p>
+                ))}
+              </div>
+            ) : (
+              <div className="text-gray-500 text-sm py-4 text-center">
+                {chapter.polish_failed ? (
+                  <span className="text-red-500">Failed to polish this chapter.</span>
+                ) : (
+                  <span>Chapter text is being processed...</span>
+                )}
+              </div>
+            )}
+
+            {/* Footer with link to full page view */}
+            <div className="mt-4 pt-3 border-t flex justify-end">
+              <Link
+                to="/books/$bookId/pages/$pageNum"
+                params={{ bookId, pageNum: String(chapter.start_page) }}
+                className="text-blue-600 hover:text-blue-800 text-sm"
+              >
+                View pages {chapter.start_page}–{chapter.end_page} →
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/book/tabs/TocTab.tsx
+++ b/web/src/components/book/tabs/TocTab.tsx
@@ -1,0 +1,223 @@
+import { useState, useMemo } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useDetailedStatus, type BookData } from './useBookData'
+import type { TocEntry } from '../types'
+
+interface TocTabProps {
+  bookId: string
+  book: BookData
+}
+
+export function TocTab({ bookId, book: _book }: TocTabProps) {
+  const { data: detailedStatus, isLoading } = useDetailedStatus(bookId)
+  const [searchFilter, setSearchFilter] = useState('')
+  const [showOnlyLinked, setShowOnlyLinked] = useState(false)
+  const [showOnlyDiscovered, setShowOnlyDiscovered] = useState(false)
+
+  const toc = detailedStatus?.toc
+  const entries = toc?.entries || []
+
+  // Filter entries
+  const filteredEntries = useMemo(() => {
+    let result = [...entries]
+
+    if (searchFilter) {
+      const lower = searchFilter.toLowerCase()
+      result = result.filter(
+        (e: TocEntry) =>
+          e.title?.toLowerCase().includes(lower) ||
+          e.entry_number?.toLowerCase().includes(lower) ||
+          e.level_name?.toLowerCase().includes(lower)
+      )
+    }
+
+    if (showOnlyLinked) {
+      result = result.filter((e: TocEntry) => e.is_linked && e.actual_page_num)
+    }
+
+    if (showOnlyDiscovered) {
+      result = result.filter((e: TocEntry) => e.source === 'discovered')
+    }
+
+    return result
+  }, [entries, searchFilter, showOnlyLinked, showOnlyDiscovered])
+
+  // Stats
+  const linkedCount = entries.filter((e: TocEntry) => e.is_linked).length
+  const discoveredCount = entries.filter((e: TocEntry) => e.source === 'discovered').length
+  const totalCount = entries.length
+
+  if (isLoading) {
+    return (
+      <div className="text-center py-12">
+        <div className="text-gray-500">Loading table of contents...</div>
+      </div>
+    )
+  }
+
+  if (!toc?.found) {
+    return (
+      <div className="bg-white border rounded-lg p-12 text-center">
+        <div className="text-gray-400 text-5xl mb-4">📑</div>
+        <h3 className="text-lg font-medium text-gray-900 mb-2">Table of Contents Not Found</h3>
+        <p className="text-gray-500 mb-4">
+          The table of contents has not been extracted yet. This happens during the ToC processing stage.
+        </p>
+        <Link
+          to="/books/$bookId/pages/$pageNum"
+          params={{ bookId, pageNum: '1' }}
+          className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+        >
+          Browse Pages
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* ToC Header Info */}
+      <div className="bg-white border rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-medium text-gray-900">Table of Contents</h3>
+            <p className="text-sm text-gray-500">
+              Found on pages {toc.start_page}–{toc.end_page}
+            </p>
+          </div>
+          <Link
+            to="/books/$bookId/pages/$pageNum"
+            params={{ bookId, pageNum: String(toc.start_page) }}
+            className="text-blue-600 hover:text-blue-800 text-sm"
+          >
+            View ToC Pages →
+          </Link>
+        </div>
+
+        {/* Stats */}
+        <div className="flex items-center space-x-6 mt-4 pt-4 border-t">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-gray-900">{totalCount}</div>
+            <div className="text-xs text-gray-500">Total Entries</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600">{linkedCount}</div>
+            <div className="text-xs text-gray-500">Linked</div>
+          </div>
+          {discoveredCount > 0 && (
+            <div className="text-center">
+              <div className="text-2xl font-bold text-blue-600">+{discoveredCount}</div>
+              <div className="text-xs text-gray-500">Discovered</div>
+            </div>
+          )}
+          <div className="flex-1" />
+          <div className="text-sm text-gray-500">
+            {totalCount > 0 ? Math.round((linkedCount / totalCount) * 100) : 0}% linked
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-white border rounded-lg p-3">
+        <div className="flex items-center space-x-4">
+          <div className="flex-1">
+            <input
+              type="text"
+              value={searchFilter}
+              onChange={(e) => setSearchFilter(e.target.value)}
+              placeholder="Search entries..."
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+            />
+          </div>
+          <label className="flex items-center space-x-2 text-sm">
+            <input
+              type="checkbox"
+              checked={showOnlyLinked}
+              onChange={(e) => setShowOnlyLinked(e.target.checked)}
+              className="rounded border-gray-300 text-blue-600"
+            />
+            <span className="text-gray-600">Linked only</span>
+          </label>
+          {discoveredCount > 0 && (
+            <label className="flex items-center space-x-2 text-sm">
+              <input
+                type="checkbox"
+                checked={showOnlyDiscovered}
+                onChange={(e) => setShowOnlyDiscovered(e.target.checked)}
+                className="rounded border-gray-300 text-blue-600"
+              />
+              <span className="text-gray-600">Discovered only</span>
+            </label>
+          )}
+        </div>
+        <div className="mt-2 text-xs text-gray-500">
+          Showing {filteredEntries.length} of {totalCount} entries
+        </div>
+      </div>
+
+      {/* Entries Table */}
+      <div className="bg-white border rounded-lg overflow-hidden">
+        <div className="grid grid-cols-12 gap-2 bg-gray-50 px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider border-b">
+          <div className="col-span-1">#</div>
+          <div className="col-span-6">Title</div>
+          <div className="col-span-2">Type</div>
+          <div className="col-span-1 text-right">Print</div>
+          <div className="col-span-2 text-right">Scan Page</div>
+        </div>
+        <div className="max-h-[32rem] overflow-y-auto divide-y">
+          {filteredEntries.length === 0 ? (
+            <div className="px-4 py-8 text-center text-gray-500">No entries match your filters</div>
+          ) : (
+            filteredEntries.map((entry: TocEntry, idx: number) => (
+              <TocEntryRow key={idx} entry={entry} bookId={bookId} />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TocEntryRow({ entry, bookId }: { entry: TocEntry; bookId: string }) {
+  const level = entry.level || 0
+  const isDiscovered = entry.source === 'discovered'
+  const isLinked = entry.is_linked && entry.actual_page_num
+
+  return (
+    <div
+      className={`grid grid-cols-12 gap-2 px-4 py-3 text-sm hover:bg-gray-50 ${
+        isDiscovered ? 'bg-green-50/50' : ''
+      }`}
+    >
+      <div className="col-span-1 font-mono text-xs text-gray-400">{entry.entry_number || '-'}</div>
+      <div className="col-span-6 flex items-center">
+        <div style={{ width: `${level * 16}px` }} className="flex-shrink-0" />
+        <span className={level === 0 ? 'font-medium' : ''}>{entry.title || 'Untitled'}</span>
+      </div>
+      <div className="col-span-2">
+        <div className="flex items-center space-x-1">
+          {entry.level_name && <span className="text-xs text-gray-500">{entry.level_name}</span>}
+          {isDiscovered && (
+            <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">new</span>
+          )}
+        </div>
+      </div>
+      <div className="col-span-1 text-right font-mono text-gray-500">
+        {entry.printed_page_number || '-'}
+      </div>
+      <div className="col-span-2 text-right">
+        {isLinked ? (
+          <Link
+            to="/books/$bookId/pages/$pageNum"
+            params={{ bookId, pageNum: String(entry.actual_page_num) }}
+            className="font-mono text-blue-600 hover:text-blue-800"
+          >
+            p.{entry.actual_page_num}
+          </Link>
+        ) : (
+          <span className="text-gray-300">—</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/book/tabs/index.ts
+++ b/web/src/components/book/tabs/index.ts
@@ -1,0 +1,5 @@
+export { OverviewTab } from './OverviewTab'
+export { ReadTab } from './ReadTab'
+export { TocTab } from './TocTab'
+export { ProcessingTab } from './ProcessingTab'
+export * from './useBookData'

--- a/web/src/components/book/tabs/useBookData.ts
+++ b/web/src/components/book/tabs/useBookData.ts
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query'
+import { client, unwrap } from '@/api/client'
+import type { StageMetrics } from '../types'
+
+export interface BookData {
+  id: string
+  title?: string
+  author?: string
+  page_count?: number
+  status?: string
+  page_pattern_analysis_json?: string
+}
+
+export interface CostData {
+  total_cost_usd?: number
+  breakdown?: Record<string, number>
+}
+
+export interface DetailedMetrics {
+  book_id: string
+  stages: Record<string, StageMetrics>
+}
+
+export function useBookData(bookId: string) {
+  return useQuery({
+    queryKey: ['books', bookId],
+    queryFn: async () =>
+      unwrap(
+        await client.GET('/api/books/{id}', {
+          params: { path: { id: bookId } },
+        })
+      ) as BookData,
+  })
+}
+
+export function useBookCost(bookId: string) {
+  return useQuery({
+    queryKey: ['books', bookId, 'cost'],
+    queryFn: async () =>
+      unwrap(
+        await client.GET('/api/books/{id}/cost', {
+          params: { path: { id: bookId }, query: { by: 'stage' } },
+        })
+      ) as CostData,
+  })
+}
+
+export function useDetailedStatus(bookId: string) {
+  return useQuery({
+    queryKey: ['jobs', 'status', bookId, 'detailed'],
+    queryFn: async () =>
+      unwrap(
+        await client.GET('/api/jobs/status/{book_id}/detailed', {
+          params: { path: { book_id: bookId } },
+        })
+      ),
+    refetchInterval: 5000,
+  })
+}
+
+export function useDetailedMetrics(bookId: string) {
+  return useQuery({
+    queryKey: ['books', bookId, 'metrics', 'detailed'],
+    queryFn: async () => {
+      const resp = await fetch(`/api/books/${bookId}/metrics/detailed`)
+      if (!resp.ok) throw new Error('Failed to fetch detailed metrics')
+      return resp.json() as Promise<DetailedMetrics>
+    },
+    refetchInterval: 10000,
+  })
+}
+
+export function useChapters(bookId: string, enabled = true) {
+  return useQuery({
+    queryKey: ['books', bookId, 'chapters'],
+    queryFn: async () => {
+      const res = await fetch(`/api/books/${bookId}/chapters`)
+      if (!res.ok) throw new Error('Failed to fetch chapters')
+      return res.json()
+    },
+    enabled,
+  })
+}
+
+export function usePages(bookId: string) {
+  return useQuery({
+    queryKey: ['books', bookId, 'pages'],
+    queryFn: async () =>
+      unwrap(
+        await client.GET('/api/books/{book_id}/pages', {
+          params: { path: { book_id: bookId } },
+        })
+      ),
+    refetchInterval: 10000,
+  })
+}

--- a/web/src/routes/books.$bookId.tsx
+++ b/web/src/routes/books.$bookId.tsx
@@ -1,28 +1,30 @@
-import { useState } from 'react'
-import { createFileRoute, Link, useNavigate, Outlet, useRouterState } from '@tanstack/react-router'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react'
-import { client, unwrap } from '@/api/client'
-import { ProgressBar, StatusBadge } from '@/components/ui'
-import {
-  CollapsibleSection,
-  TocSection,
-  StructureSection,
-  PatternAnalysisSection,
-  AgentLogModal,
-  MetadataModal,
-  JobHistorySection,
-  type StageMetrics,
-} from '@/components/book'
+import { useState, useEffect } from 'react'
+import { createFileRoute, Link, Outlet, useRouterState } from '@tanstack/react-router'
+import { OverviewTab, ReadTab, TocTab, ProcessingTab, useBookData } from '@/components/book/tabs'
+
+type TabId = 'overview' | 'read' | 'toc' | 'processing'
+
+interface BookSearchParams {
+  tab?: TabId
+}
 
 export const Route = createFileRoute('/books/$bookId')({
   component: BookDetailLayout,
+  validateSearch: (search: Record<string, unknown>): BookSearchParams => {
+    return {
+      tab: (search.tab as TabId) || undefined,
+    }
+  },
 })
 
 function BookDetailLayout() {
   const routerState = useRouterState()
   const pathname = routerState.location.pathname
-  const isChildRoute = pathname.includes('/pages') || pathname.includes('/pages-table') || pathname.includes('/prompts') || pathname.includes('/chapters')
+  const isChildRoute =
+    pathname.includes('/pages') ||
+    pathname.includes('/pages-table') ||
+    pathname.includes('/prompts') ||
+    pathname.includes('/chapters')
 
   if (isChildRoute) {
     return <Outlet />
@@ -31,426 +33,143 @@ function BookDetailLayout() {
   return <BookDetailPage />
 }
 
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'read', label: 'Read' },
+  { id: 'toc', label: 'Contents' },
+  { id: 'processing', label: 'Processing' },
+]
+
 function BookDetailPage() {
   const { bookId } = Route.useParams()
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
-  const [metadataModalOpen, setMetadataModalOpen] = useState(false)
-  const [agentLogModalOpen, setAgentLogModalOpen] = useState(false)
-  const [selectedAgentLogId, setSelectedAgentLogId] = useState<string | null>(null)
+  const search = Route.useSearch()
+  const [activeTab, setActiveTab] = useState<TabId>(search.tab || 'overview')
 
-  const startJobMutation = useMutation({
-    mutationFn: async (params: { jobType?: string; force?: boolean }) => {
-      const { jobType, force } = params
-      const result = await client.POST('/api/jobs/start/{book_id}', {
-        params: { path: { book_id: bookId } },
-        body: { job_type: jobType || 'process-book', force: force || false },
-      })
-      return unwrap(result)
-    },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['jobs', 'status', bookId] })
-      queryClient.invalidateQueries({ queryKey: ['books', bookId] })
-      if (data?.job_id) {
-        navigate({ to: '/jobs/$jobId', params: { jobId: data.job_id } })
-      }
-    },
-  })
+  // Sync tab with URL search param
+  useEffect(() => {
+    if (search.tab && search.tab !== activeTab) {
+      setActiveTab(search.tab)
+    }
+  }, [search.tab, activeTab])
 
-  const jobTypes = [
-    { id: 'process-book', label: 'Full Pipeline', description: 'OCR → Blend → Pattern Analysis → Label → ToC → Structure', force: false },
-    { id: 'ocr-book', label: 'OCR + Blend Only', description: 'OCR and blend all pages (no pattern analysis or labeling)', force: false },
-    { id: 'label-book', label: 'Label Only', description: 'Label pages (requires pattern analysis complete)', force: false },
-    { id: 'metadata-book', label: 'Metadata Only', description: 'Extract book metadata (title, author, etc.)', force: false },
-    { id: 'toc-book', label: 'ToC Only', description: 'Find and extract table of contents', force: false },
-    { id: 'link-toc', label: 'Link ToC Only', description: 'Link ToC entries to actual pages', force: false },
-    { id: 'link-toc', label: 'Link ToC (Force)', description: 'Re-link ToC entries even if already complete', force: true },
-  ]
-
-  const { data: book, isLoading, error } = useQuery({
-    queryKey: ['books', bookId],
-    queryFn: async () =>
-      unwrap(
-        await client.GET('/api/books/{id}', {
-          params: { path: { id: bookId } },
-        })
-      ),
-  })
-
-  const { data: cost, error: costError } = useQuery({
-    queryKey: ['books', bookId, 'cost'],
-    queryFn: async () =>
-      unwrap(
-        await client.GET('/api/books/{id}/cost', {
-          params: { path: { id: bookId }, query: { by: 'stage' } },
-        })
-      ),
-  })
-
-  const { data: detailedStatus } = useQuery({
-    queryKey: ['jobs', 'status', bookId, 'detailed'],
-    queryFn: async () =>
-      unwrap(
-        await client.GET('/api/jobs/status/{book_id}/detailed', {
-          params: { path: { book_id: bookId } },
-        })
-      ),
-    refetchInterval: 5000,
-  })
-
-  const { data: detailedMetrics } = useQuery({
-    queryKey: ['books', bookId, 'metrics', 'detailed'],
-    queryFn: async () => {
-      const resp = await fetch(`/api/books/${bookId}/metrics/detailed`)
-      if (!resp.ok) throw new Error('Failed to fetch detailed metrics')
-      return resp.json() as Promise<{
-        book_id: string
-        stages: Record<string, StageMetrics>
-      }>
-    },
-    refetchInterval: 10000,
-  })
-
-  const { data: agentLogDetail } = useQuery({
-    queryKey: ['agent-logs', selectedAgentLogId],
-    queryFn: async () =>
-      selectedAgentLogId
-        ? unwrap(
-            await client.GET('/api/agent-logs/{id}', {
-              params: { path: { id: selectedAgentLogId } },
-            })
-          )
-        : null,
-    enabled: !!selectedAgentLogId,
-  })
+  const { data: book, isLoading, error } = useBookData(bookId)
 
   if (isLoading) {
     return (
-      <div className="text-center py-12">
-        <div className="text-gray-500">Loading book...</div>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full mx-auto mb-4" />
+          <div className="text-gray-500">Loading book...</div>
+        </div>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="text-center py-12">
-        <div className="text-red-500">Error loading book: {error.message}</div>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-red-500 text-5xl mb-4">!</div>
+          <div className="text-red-600 font-medium">Error loading book</div>
+          <div className="text-gray-500 text-sm mt-1">{error.message}</div>
+          <Link to="/books" className="mt-4 inline-block text-blue-600 hover:text-blue-800">
+            Back to Library
+          </Link>
+        </div>
       </div>
     )
   }
 
   if (!book) {
     return (
-      <div className="text-center py-12">
-        <div className="text-gray-500">Book not found</div>
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-gray-400 text-5xl mb-4">?</div>
+          <div className="text-gray-600 font-medium">Book not found</div>
+          <Link to="/books" className="mt-4 inline-block text-blue-600 hover:text-blue-800">
+            Back to Library
+          </Link>
+        </div>
       </div>
     )
   }
 
+  const handleTabChange = (tabId: TabId) => {
+    setActiveTab(tabId)
+    // Update URL without full navigation
+    const url = new URL(window.location.href)
+    url.searchParams.set('tab', tabId)
+    window.history.replaceState(null, '', url.toString())
+  }
+
   return (
-    <div className="space-y-6">
-      {/* Breadcrumb */}
-      <nav className="text-sm">
-        <Link to="/books" className="text-blue-600 hover:text-blue-800">
-          Library
-        </Link>
-        <span className="mx-2 text-gray-400">/</span>
-        <span className="text-gray-600">{book.title}</span>
-      </nav>
-
+    <div className="min-h-screen bg-gray-50">
       {/* Header */}
-      <div className="flex justify-between items-start">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">{book.title}</h1>
-          {book.author && <p className="text-gray-500">{book.author}</p>}
-        </div>
-        <div className="flex items-center space-x-3">
-          <Link
-            to="/books/$bookId/pages/$pageNum"
-            params={{ bookId, pageNum: '1' }}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-          >
-            View Pages
-          </Link>
-          <Link
-            to="/books/$bookId/pages-table"
-            params={{ bookId }}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-          >
-            Pages Table
-          </Link>
-          <Link
-            to="/books/$bookId/chapters"
-            params={{ bookId }}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-          >
-            Chapters
-          </Link>
-          <Link
-            to="/books/$bookId/prompts"
-            params={{ bookId }}
-            className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
-          >
-            Prompts
-          </Link>
-          {book.status !== 'error' && (
-            <div className="flex items-center">
-              <button
-                onClick={() => startJobMutation.mutate({ jobType: 'process-book' })}
-                disabled={startJobMutation.isPending}
-                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-l-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {startJobMutation.isPending ? 'Starting...' : 'Start Processing'}
-              </button>
-              <Menu as="div" className="relative">
-                <MenuButton
-                  disabled={startJobMutation.isPending}
-                  className="inline-flex items-center px-2 py-2 border border-transparent text-sm font-medium rounded-r-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed border-l border-blue-500"
+      <header className="bg-white border-b sticky top-0 z-10">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* Breadcrumb */}
+          <nav className="py-3 text-sm">
+            <Link to="/books" className="text-blue-600 hover:text-blue-800">
+              Library
+            </Link>
+            <span className="mx-2 text-gray-400">/</span>
+            <span className="text-gray-600 truncate">{book.title}</span>
+          </nav>
+
+          {/* Title Row */}
+          <div className="pb-4">
+            <div className="flex items-start justify-between">
+              <div className="min-w-0 flex-1">
+                <h1 className="text-2xl font-bold text-gray-900 truncate">{book.title}</h1>
+                {book.author && <p className="text-gray-500 mt-1">{book.author}</p>}
+              </div>
+              <div className="ml-4 flex items-center space-x-2">
+                <span
+                  className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
+                    book.status === 'complete'
+                      ? 'bg-green-100 text-green-800'
+                      : book.status === 'processing'
+                        ? 'bg-blue-100 text-blue-800'
+                        : book.status === 'error'
+                          ? 'bg-red-100 text-red-800'
+                          : 'bg-gray-100 text-gray-800'
+                  }`}
                 >
-                  <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" />
-                  </svg>
-                </MenuButton>
-                <MenuItems className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5">
-                  <div className="py-1">
-                    {jobTypes.map((job, index) => (
-                      <MenuItem key={`${job.id}-${index}`}>
-                        {({ active }) => (
-                          <button
-                            onClick={() => startJobMutation.mutate({ jobType: job.id, force: job.force })}
-                            className={`${active ? 'bg-gray-100 text-gray-900' : 'text-gray-700'} block w-full text-left px-4 py-2 text-sm`}
-                          >
-                            <div className="font-medium">{job.label}</div>
-                            <div className="text-xs text-gray-500">{job.description}</div>
-                          </button>
-                        )}
-                      </MenuItem>
-                    ))}
-                  </div>
-                </MenuItems>
-              </Menu>
-            </div>
-          )}
-        </div>
-        {startJobMutation.isError && (
-          <p className="text-sm text-red-600 mt-2">
-            Error: {startJobMutation.error?.message || 'Failed to start job'}
-          </p>
-        )}
-      </div>
-
-      {/* Info Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-sm font-medium text-gray-500">Pages</h3>
-          <p className="mt-2 text-2xl font-semibold">{book.page_count}</p>
-        </div>
-
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-sm font-medium text-gray-500">Status</h3>
-          <p className="mt-2">
-            <span
-              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium ${
-                book.status === 'complete'
-                  ? 'bg-green-100 text-green-800'
-                  : book.status === 'processing'
-                  ? 'bg-blue-100 text-blue-800'
-                  : 'bg-gray-100 text-gray-800'
-              }`}
-            >
-              {book.status}
-            </span>
-          </p>
-        </div>
-
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-sm font-medium text-gray-500">Total Cost</h3>
-          {costError ? (
-            <p className="mt-2 text-sm text-red-500">Failed to load</p>
-          ) : cost?.total_cost_usd !== undefined ? (
-            <p className="mt-2 text-2xl font-semibold">${cost.total_cost_usd.toFixed(4)}</p>
-          ) : (
-            <p className="mt-2 text-gray-400">--</p>
-          )}
-        </div>
-      </div>
-
-      {/* Processing Progress */}
-      {detailedStatus && (
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">Processing Progress</h3>
-          <div className="space-y-4">
-            {/* OCR Section - show per-provider metrics */}
-            {detailedStatus.ocr_progress && Object.entries(detailedStatus.ocr_progress).length > 0 ? (
-              Object.entries(detailedStatus.ocr_progress).map(([provider, progress]) => (
-                <CollapsibleSection
-                  key={provider}
-                  title={`OCR: ${provider}`}
-                  current={progress.complete || 0}
-                  total={progress.total || 0}
-                  cost={progress.cost_usd}
-                  metrics={detailedMetrics?.stages?.[`ocr:${provider}`]}
-                  stageType="ocr"
-                >
-                  <div className="pl-4 border-l-2 border-gray-200">
-                    <ProgressBar
-                      label="Pages"
-                      current={progress.complete || 0}
-                      total={progress.total || 0}
-                    />
-                  </div>
-                </CollapsibleSection>
-              ))
-            ) : (
-              <CollapsibleSection
-                title="OCR"
-                current={detailedStatus.stages?.ocr?.complete || 0}
-                total={detailedStatus.stages?.ocr?.total || 0}
-                cost={detailedStatus.stages?.ocr?.total_cost_usd}
-                stageType="ocr"
-              >
-                <p className="text-sm text-gray-400 pl-4">No OCR results yet</p>
-              </CollapsibleSection>
-            )}
-
-            {/* Blend Section */}
-            <CollapsibleSection
-              title="Blend"
-              current={detailedStatus.stages?.blend?.complete || 0}
-              total={detailedStatus.stages?.blend?.total || 0}
-              cost={detailedStatus.stages?.blend?.cost_usd}
-              metrics={detailedMetrics?.stages?.['blend']}
-              stageType="blend"
-            >
-              <div className="pl-4 border-l-2 border-gray-200">
-                <ProgressBar
-                  label="Pages"
-                  current={detailedStatus.stages?.blend?.complete || 0}
-                  total={detailedStatus.stages?.blend?.total || 0}
-                />
-              </div>
-            </CollapsibleSection>
-
-            {/* Pattern Analysis Section */}
-            <PatternAnalysisSection
-              patternAnalysisJSON={book?.page_pattern_analysis_json}
-              complete={detailedStatus.stages?.pattern_analysis?.complete}
-              cost={detailedStatus.stages?.pattern_analysis?.cost_usd}
-              metrics={detailedMetrics?.stages?.['pattern_analysis']}
-            />
-
-            {/* Label Section */}
-            <CollapsibleSection
-              title="Label"
-              current={detailedStatus.stages?.label?.complete || 0}
-              total={detailedStatus.stages?.label?.total || 0}
-              cost={detailedStatus.stages?.label?.cost_usd}
-              metrics={detailedMetrics?.stages?.['label']}
-            >
-              <div className="pl-4 border-l-2 border-gray-200">
-                <ProgressBar
-                  label="Pages"
-                  current={detailedStatus.stages?.label?.complete || 0}
-                  total={detailedStatus.stages?.label?.total || 0}
-                />
-              </div>
-            </CollapsibleSection>
-
-            {/* Metadata Section */}
-            <div className="border-t pt-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-2">
-                  <span className="text-sm font-medium text-gray-700">Metadata</span>
-                  <StatusBadge
-                    status={
-                      detailedStatus.metadata?.complete
-                        ? 'complete'
-                        : detailedStatus.metadata?.failed
-                        ? 'failed'
-                        : detailedStatus.metadata?.started
-                        ? 'in_progress'
-                        : 'pending'
-                    }
-                  />
-                </div>
-                <div className="flex items-center space-x-2">
-                  {detailedStatus.metadata?.cost_usd !== undefined && (
-                    <span className="font-mono text-sm text-gray-500">
-                      ${detailedStatus.metadata.cost_usd.toFixed(4)}
-                    </span>
+                  {book.status === 'processing' && (
+                    <span className="animate-pulse mr-1.5 h-2 w-2 bg-blue-500 rounded-full" />
                   )}
-                  {detailedStatus.metadata?.complete && detailedStatus.metadata?.data && (
-                    <button
-                      onClick={() => setMetadataModalOpen(true)}
-                      className="text-sm text-blue-600 hover:text-blue-800"
-                    >
-                      View Details
-                    </button>
-                  )}
-                </div>
+                  {book.status || 'pending'}
+                </span>
               </div>
-              {detailedStatus.metadata?.complete && detailedStatus.metadata?.data && (
-                <div className="mt-2 pl-4 text-sm text-gray-600">
-                  <div>Title: {detailedStatus.metadata.data.title || '-'}</div>
-                  <div>Author: {detailedStatus.metadata.data.author || '-'}</div>
-                </div>
-              )}
             </div>
-
-            {/* ToC Section */}
-            <TocSection
-              toc={detailedStatus.toc}
-              bookId={bookId}
-              metrics={detailedMetrics?.stages}
-              onViewAgentLog={(id) => {
-                setSelectedAgentLogId(id)
-                setAgentLogModalOpen(true)
-              }}
-            />
-
-            {/* Structure Section */}
-            <StructureSection structure={detailedStatus.structure} bookId={bookId} metrics={detailedMetrics?.stages} />
           </div>
-        </div>
-      )}
 
-      {/* Cost Breakdown */}
-      {cost?.breakdown && Object.keys(cost.breakdown).length > 0 && (
-        <div className="bg-white rounded-lg shadow p-6">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">Cost Breakdown</h3>
-          <div className="space-y-2">
-            {Object.entries(cost.breakdown).map(([stage, amount]) => (
-              <div key={stage} className="flex justify-between text-sm">
-                <span className="text-gray-600">{stage}</span>
-                <span className="font-mono">${(amount as number).toFixed(4)}</span>
-              </div>
+          {/* Tabs */}
+          <div className="flex space-x-1 -mb-px">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => handleTabChange(tab.id)}
+                className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === tab.id
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.label}
+              </button>
             ))}
           </div>
         </div>
-      )}
+      </header>
 
-      {/* Job History */}
-      <JobHistorySection bookId={bookId} />
-
-      {/* Metadata Modal */}
-      {metadataModalOpen && detailedStatus?.metadata?.data && (
-        <MetadataModal
-          data={detailedStatus.metadata.data}
-          onClose={() => setMetadataModalOpen(false)}
-        />
-      )}
-
-      {/* Agent Log Modal */}
-      {agentLogModalOpen && (
-        <AgentLogModal
-          detail={agentLogDetail || null}
-          onClose={() => {
-            setAgentLogModalOpen(false)
-            setSelectedAgentLogId(null)
-          }}
-        />
-      )}
+      {/* Tab Content */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        {activeTab === 'overview' && <OverviewTab bookId={bookId} book={book} />}
+        {activeTab === 'read' && <ReadTab bookId={bookId} book={book} />}
+        {activeTab === 'toc' && <TocTab bookId={bookId} book={book} />}
+        {activeTab === 'processing' && <ProcessingTab bookId={bookId} book={book} />}
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Replace monolithic 450+ line BookDetailPage with clean tabbed organization
- **Overview tab**: book stats, cost summary, structure breakdown, quick actions
- **Read tab**: chapter-by-chapter reading experience with matter type filtering
- **Contents tab**: searchable/filterable ToC with linked entry navigation  
- **Processing tab**: pipeline status, job controls, and debugging info (moved from main view)

## Changes

New component structure:
```
web/src/components/book/tabs/
├── useBookData.ts     # shared data hooks
├── OverviewTab.tsx    # summary & stats
├── ReadTab.tsx        # chapter reading
├── TocTab.tsx         # table of contents
└── ProcessingTab.tsx  # pipeline & debugging
```

Main page reduced from **457 → 175 lines** with clear separation of concerns.

## Motivation

The old design was developer-focused with processing pipeline dominating the view. The new design:
- Shows book info first (Overview) for completed books
- Isolates processing/debugging to its own tab
- Provides dedicated reading experience (Read tab)
- Makes ToC browsable and searchable (Contents tab)

## Test plan

- [ ] Verify Overview tab shows correct stats and cost
- [ ] Verify Read tab loads chapters and allows filtering by matter type
- [ ] Verify Contents tab shows ToC entries with search/filter working
- [ ] Verify Processing tab shows pipeline status and job history
- [ ] Verify tab switching updates URL (`?tab=...`) and persists on refresh
- [ ] Verify child routes (pages, pages-table, chapters, prompts) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)