### PR TITLE
feat: post-ToC content classification for audiobook output

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -45,31 +45,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.AgentLogDetailResponse"
+                            "$ref": "#/definitions/endpoints.AgentLogDetailResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -89,19 +89,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListBooksResponse"
+                            "$ref": "#/definitions/endpoints.ListBooksResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -127,7 +127,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.IngestRequest"
+                            "$ref": "#/definitions/endpoints.IngestRequest"
                         }
                     }
                 ],
@@ -135,25 +135,25 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.IngestResponse"
+                            "$ref": "#/definitions/endpoints.IngestResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -203,25 +203,25 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.IngestResponse"
+                            "$ref": "#/definitions/endpoints.IngestResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -268,25 +268,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.AgentLogsListResponse"
+                            "$ref": "#/definitions/endpoints.AgentLogsListResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -316,25 +316,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.AudioStatusResponse"
+                            "$ref": "#/definitions/endpoints.AudioStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -377,13 +377,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -413,25 +413,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.EpubExportResponse"
+                            "$ref": "#/definitions/endpoints.EpubExportResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -467,13 +467,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -504,25 +504,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StorytellerExportResponse"
+                            "$ref": "#/definitions/endpoints.StorytellerExportResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -559,13 +559,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -598,7 +598,7 @@ const docTemplate = `{
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GenerateAudioRequest"
+                            "$ref": "#/definitions/endpoints.GenerateAudioRequest"
                         }
                     }
                 ],
@@ -606,31 +606,31 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GenerateAudioResponse"
+                            "$ref": "#/definitions/endpoints.GenerateAudioResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -659,25 +659,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListPagesResponse"
+                            "$ref": "#/definitions/endpoints.ListPagesResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -713,31 +713,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GetPageResponse"
+                            "$ref": "#/definitions/endpoints.GetPageResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -779,19 +779,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -820,37 +820,37 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.RerunTocResponse"
+                            "$ref": "#/definitions/endpoints.RerunTocResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "412": {
                         "description": "Not enough pages have OCR complete",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -879,31 +879,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.Book"
+                            "$ref": "#/definitions/endpoints.Book"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -944,25 +944,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ChaptersResponse"
+                            "$ref": "#/definitions/endpoints.ChaptersResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -997,25 +997,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsCostResponse"
+                            "$ref": "#/definitions/endpoints.MetricsCostResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1045,25 +1045,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsDetailedResponse"
+                            "$ref": "#/definitions/endpoints.MetricsDetailedResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1092,13 +1092,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptsListResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptsListResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1134,19 +1134,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1184,7 +1184,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SetPromptRequest"
+                            "$ref": "#/definitions/endpoints.SetPromptRequest"
                         }
                     }
                 ],
@@ -1192,19 +1192,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1238,19 +1238,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1270,7 +1270,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.HealthResponse"
+                            "$ref": "#/definitions/endpoints.HealthResponse"
                         }
                     }
                 }
@@ -1310,19 +1310,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListJobsResponse"
+                            "$ref": "#/definitions/endpoints.ListJobsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1346,7 +1346,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.CreateJobRequest"
+                            "$ref": "#/definitions/endpoints.CreateJobRequest"
                         }
                     }
                 ],
@@ -1354,25 +1354,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.CreateJobResponse"
+                            "$ref": "#/definitions/endpoints.CreateJobResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1404,7 +1404,7 @@ const docTemplate = `{
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StartJobRequest"
+                            "$ref": "#/definitions/endpoints.StartJobRequest"
                         }
                     }
                 ],
@@ -1412,25 +1412,25 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StartJobResponse"
+                            "$ref": "#/definitions/endpoints.StartJobResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1465,25 +1465,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.JobStatusResponse"
+                            "$ref": "#/definitions/endpoints.JobStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1512,25 +1512,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.DetailedJobStatusResponse"
+                            "$ref": "#/definitions/endpoints.DetailedJobStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1559,31 +1559,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GetJobResponse"
+                            "$ref": "#/definitions/endpoints.GetJobResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1610,25 +1610,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1659,7 +1659,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.UpdateJobRequest"
+                            "$ref": "#/definitions/endpoints.UpdateJobRequest"
                         }
                     }
                 ],
@@ -1673,19 +1673,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1773,19 +1773,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.LLMCallsResponse"
+                            "$ref": "#/definitions/endpoints.LLMCallsResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1814,13 +1814,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.LLMCallCountsResponse"
+                            "$ref": "#/definitions/endpoints.LLMCallCountsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1849,19 +1849,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.LLMCallResponse"
+                            "$ref": "#/definitions/endpoints.LLMCallResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1919,19 +1919,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListMetricsResponse"
+                            "$ref": "#/definitions/endpoints.ListMetricsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1989,19 +1989,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsCostResponse"
+                            "$ref": "#/definitions/endpoints.MetricsCostResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2029,19 +2029,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsDetailedResponse"
+                            "$ref": "#/definitions/endpoints.MetricsDetailedResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2093,19 +2093,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsSummaryResponse"
+                            "$ref": "#/definitions/endpoints.MetricsSummaryResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2125,13 +2125,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.PromptsListResponse"
+                            "$ref": "#/definitions/endpoints.PromptsListResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2160,19 +2160,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.PromptResponse"
+                            "$ref": "#/definitions/endpoints.PromptResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2192,13 +2192,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.HealthResponse"
+                            "$ref": "#/definitions/endpoints.HealthResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.HealthResponse"
+                            "$ref": "#/definitions/endpoints.HealthResponse"
                         }
                     }
                 }
@@ -2218,13 +2218,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingsResponse"
+                            "$ref": "#/definitions/endpoints.SettingsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2253,25 +2253,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingResponse"
+                            "$ref": "#/definitions/endpoints.SettingResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2300,19 +2300,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingResponse"
+                            "$ref": "#/definitions/endpoints.SettingResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2343,7 +2343,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.UpdateSettingRequest"
+                            "$ref": "#/definitions/endpoints.UpdateSettingRequest"
                         }
                     }
                 ],
@@ -2351,19 +2351,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingResponse"
+                            "$ref": "#/definitions/endpoints.SettingResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2383,7 +2383,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StatusResponse"
+                            "$ref": "#/definitions/endpoints.StatusResponse"
                         }
                     }
                 }
@@ -2403,19 +2403,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.TTSConfigResponse"
+                            "$ref": "#/definitions/endpoints.TTSConfigResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2435,13 +2435,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListVoicesResponse"
+                            "$ref": "#/definitions/endpoints.ListVoicesResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2465,7 +2465,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.CreateVoiceRequest"
+                            "$ref": "#/definitions/endpoints.CreateVoiceRequest"
                         }
                     }
                 ],
@@ -2473,19 +2473,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.VoiceResponse"
+                            "$ref": "#/definitions/endpoints.VoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2505,13 +2505,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SyncVoicesResponse"
+                            "$ref": "#/definitions/endpoints.SyncVoicesResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2549,13 +2549,13 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2593,19 +2593,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2613,6 +2613,1559 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "endpoints.AgentLogDetailResponse": {
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "iterations": {
+                    "type": "integer"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "messages": {
+                    "description": "Detailed data",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "result": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "tool_calls": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "endpoints.AgentLogSummary": {
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "iterations": {
+                    "type": "integer"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.AgentLogSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "iterations": {
+                    "type": "integer"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.AgentLogsListResponse": {
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.AgentLogSummaryResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.AudioStatusResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "chapters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterAudioStatus"
+                    }
+                },
+                "format": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "segment_count": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "total_cost_usd": {
+                    "type": "number"
+                },
+                "total_duration_ms": {
+                    "type": "integer"
+                },
+                "voice": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.Book": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "page_count": {
+                    "type": "integer"
+                },
+                "page_pattern_analysis_json": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.BookMetadata": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "authors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isbn": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "lccn": {
+                    "type": "string"
+                },
+                "publication_year": {
+                    "type": "integer"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "subjects": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.BookPromptResponse": {
+            "type": "object",
+            "properties": {
+                "cid": {
+                    "type": "string"
+                },
+                "is_override": {
+                    "type": "boolean"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "endpoints.BookPromptsListResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.BookPromptResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.ChapterAudioStatus": {
+            "type": "object",
+            "properties": {
+                "audio_file": {
+                    "type": "string"
+                },
+                "chapter_idx": {
+                    "type": "integer"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "download_url": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "segment_count": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ChapterPage": {
+            "type": "object",
+            "properties": {
+                "ocr_markdown": {
+                    "type": "string"
+                },
+                "page_num": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ChapterParagraph": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "polished_text": {
+                    "type": "string"
+                },
+                "raw_text": {
+                    "type": "string"
+                },
+                "sort_order": {
+                    "type": "integer"
+                },
+                "start_page": {
+                    "type": "integer"
+                },
+                "word_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ChapterWithText": {
+            "type": "object",
+            "properties": {
+                "audio_include": {
+                    "type": "boolean"
+                },
+                "audio_include_reasoning": {
+                    "type": "string"
+                },
+                "classification_reasoning": {
+                    "type": "string"
+                },
+                "content_type": {
+                    "type": "string"
+                },
+                "edits_applied_json": {
+                    "type": "string"
+                },
+                "end_page": {
+                    "type": "integer"
+                },
+                "entry_id": {
+                    "type": "string"
+                },
+                "entry_number": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "level_name": {
+                    "type": "string"
+                },
+                "matter_type": {
+                    "type": "string"
+                },
+                "page_count": {
+                    "type": "integer"
+                },
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterPage"
+                    }
+                },
+                "paragraphs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterParagraph"
+                    }
+                },
+                "polish_complete": {
+                    "type": "boolean"
+                },
+                "polish_failed": {
+                    "type": "boolean"
+                },
+                "polished_text": {
+                    "type": "string"
+                },
+                "sort_order": {
+                    "type": "integer"
+                },
+                "start_page": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "word_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ChaptersResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "book_title": {
+                    "type": "string"
+                },
+                "chapters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterWithText"
+                    }
+                },
+                "has_chapters": {
+                    "type": "boolean"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.CreateJobRequest": {
+            "type": "object",
+            "properties": {
+                "job_type": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "endpoints.CreateJobResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.CreateVoiceRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "voice_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.DefraStatus": {
+            "type": "object",
+            "properties": {
+                "container": {
+                    "type": "string"
+                },
+                "health": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.DetailedJobStatusResponse": {
+            "type": "object",
+            "properties": {
+                "agent_logs": {
+                    "description": "Agent logs summary",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.AgentLogSummary"
+                    }
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Metadata status",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.MetadataStatus"
+                        }
+                    ]
+                },
+                "ocr_progress": {
+                    "description": "Per-provider OCR progress",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/endpoints.ProviderProgress"
+                    }
+                },
+                "stages": {
+                    "description": "Stage progress with costs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.StageProgress"
+                        }
+                    ]
+                },
+                "structure": {
+                    "description": "Structure status (common-structure job)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.StructureStatus"
+                        }
+                    ]
+                },
+                "toc": {
+                    "description": "ToC status",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.ToCStatus"
+                        }
+                    ]
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.DiscoveredPattern": {
+            "type": "object",
+            "properties": {
+                "heading_format": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "level_name": {
+                    "type": "string"
+                },
+                "pattern_type": {
+                    "type": "string"
+                },
+                "range_end": {
+                    "type": "string"
+                },
+                "range_start": {
+                    "type": "string"
+                },
+                "reasoning": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.EpubExportResponse": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "download_url": {
+                    "type": "string"
+                },
+                "file_path": {
+                    "type": "string"
+                },
+                "file_size": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ExcludedRange": {
+            "type": "object",
+            "properties": {
+                "end_page": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "start_page": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.GenerateAudioRequest": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "description": "Optional: output format (mp3, wav)",
+                    "type": "string"
+                },
+                "voice": {
+                    "description": "Optional: voice ID",
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.GenerateAudioResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "chapters": {
+                    "type": "integer"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.GetJobResponse": {
+            "type": "object",
+            "properties": {
+                "_docID": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "job_type": {
+                    "type": "string"
+                },
+                "live_status": {
+                    "description": "Live status fields (only populated for running jobs)",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "pending_units": {
+                    "type": "integer"
+                },
+                "progress": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Status"
+                },
+                "worker_status": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"
+                    }
+                }
+            }
+        },
+        "endpoints.GetPageResponse": {
+            "type": "object",
+            "properties": {
+                "ocr_markdown": {
+                    "type": "string"
+                },
+                "ocr_results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.OcrResult"
+                    }
+                },
+                "page_num": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/endpoints.PageStatus"
+                }
+            }
+        },
+        "endpoints.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "defra": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.IngestRequest": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "pdf_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.IngestResponse": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "process_job_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.JobStatusResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "is_complete": {
+                    "type": "boolean"
+                },
+                "job_type": {
+                    "type": "string"
+                },
+                "metadata_complete": {
+                    "type": "boolean"
+                },
+                "ocr_complete": {
+                    "type": "integer"
+                },
+                "toc_extracted": {
+                    "type": "boolean"
+                },
+                "toc_found": {
+                    "type": "boolean"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.LLMCallCountsResponse": {
+            "type": "object",
+            "properties": {
+                "counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "endpoints.LLMCallResponse": {
+            "type": "object",
+            "properties": {
+                "call": {
+                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
+                },
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.LLMCallsResponse": {
+            "type": "object",
+            "properties": {
+                "calls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ListBooksResponse": {
+            "type": "object",
+            "properties": {
+                "books": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.Book"
+                    }
+                }
+            }
+        },
+        "endpoints.ListJobsResponse": {
+            "type": "object",
+            "properties": {
+                "jobs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Record"
+                    }
+                }
+            }
+        },
+        "endpoints.ListMetricsResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.Metric"
+                    }
+                }
+            }
+        },
+        "endpoints.ListPagesResponse": {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.PageSummary"
+                    }
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ListVoicesResponse": {
+            "type": "object",
+            "properties": {
+                "voices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.VoiceResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.MetadataStatus": {
+            "type": "object",
+            "properties": {
+                "complete": {
+                    "type": "boolean"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "data": {
+                    "$ref": "#/definitions/endpoints.BookMetadata"
+                },
+                "failed": {
+                    "type": "boolean"
+                },
+                "started": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.MetricsCostResponse": {
+            "type": "object",
+            "properties": {
+                "breakdown": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "number",
+                        "format": "float64"
+                    }
+                },
+                "total_cost_usd": {
+                    "type": "number"
+                }
+            }
+        },
+        "endpoints.MetricsDetailedResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "stages": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.DetailedStats"
+                    }
+                }
+            }
+        },
+        "endpoints.MetricsSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "avg_cost_usd": {
+                    "type": "number"
+                },
+                "avg_time_seconds": {
+                    "type": "number"
+                },
+                "avg_tokens": {
+                    "type": "number"
+                },
+                "count": {
+                    "type": "integer"
+                },
+                "error_count": {
+                    "type": "integer"
+                },
+                "success_count": {
+                    "type": "integer"
+                },
+                "total_cost_usd": {
+                    "type": "number"
+                },
+                "total_time_seconds": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.OcrResult": {
+            "type": "object",
+            "properties": {
+                "confidence": {
+                    "type": "number"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.PageStatus": {
+            "type": "object",
+            "properties": {
+                "extract_complete": {
+                    "type": "boolean"
+                },
+                "ocr_complete": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.PageSummary": {
+            "type": "object",
+            "properties": {
+                "ocr_complete": {
+                    "type": "boolean"
+                },
+                "page_num": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.PatternAnalysisResult": {
+            "type": "object",
+            "properties": {
+                "excluded_ranges": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ExcludedRange"
+                    }
+                },
+                "patterns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.DiscoveredPattern"
+                    }
+                },
+                "reasoning": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.PromptResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "doc_id": {
+                    "type": "string"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "endpoints.PromptsListResponse": {
+            "type": "object",
+            "properties": {
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.PromptResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.ProviderProgress": {
+            "type": "object",
+            "properties": {
+                "complete": {
+                    "type": "integer"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ProvidersStatus": {
+            "type": "object",
+            "properties": {
+                "llm": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ocr": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "endpoints.RerunTocResponse": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.SetPromptRequest": {
+            "type": "object",
+            "properties": {
+                "note": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.SettingResponse": {
+            "type": "object",
+            "properties": {
+                "entry": {
+                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
+                },
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.SettingsResponse": {
+            "type": "object",
+            "properties": {
+                "settings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
+                    }
+                }
+            }
+        },
+        "endpoints.StageProgress": {
+            "type": "object",
+            "properties": {
+                "ocr": {
+                    "type": "object",
+                    "properties": {
+                        "complete": {
+                            "type": "integer"
+                        },
+                        "cost_by_provider": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "number",
+                                "format": "float64"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        },
+                        "total_cost_usd": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "pattern_analysis": {
+                    "type": "object",
+                    "properties": {
+                        "complete": {
+                            "type": "boolean"
+                        },
+                        "cost_usd": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "endpoints.StartJobRequest": {
+            "type": "object",
+            "properties": {
+                "force": {
+                    "description": "Optional: force restart even if already complete",
+                    "type": "boolean"
+                },
+                "job_type": {
+                    "description": "Optional: defaults to \"process-book\"",
+                    "type": "string"
+                },
+                "reset_from": {
+                    "description": "Optional: reset this operation and downstream deps before starting",
+                    "type": "string"
+                },
+                "variant": {
+                    "description": "Optional: pipeline variant (standard, photo-book, text-only, ocr-only)",
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.StartJobResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "job_type": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.StatusResponse": {
+            "type": "object",
+            "properties": {
+                "defra": {
+                    "$ref": "#/definitions/endpoints.DefraStatus"
+                },
+                "providers": {
+                    "$ref": "#/definitions/endpoints.ProvidersStatus"
+                },
+                "server": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.StorytellerExportResponse": {
+            "type": "object",
+            "properties": {
+                "audio_chapters": {
+                    "type": "integer"
+                },
+                "author": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "download_url": {
+                    "type": "string"
+                },
+                "file_path": {
+                    "type": "string"
+                },
+                "file_size": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "total_duration_ms": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.StructureStatus": {
+            "type": "object",
+            "properties": {
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "chapters_extracted": {
+                    "type": "integer"
+                },
+                "chapters_polished": {
+                    "type": "integer"
+                },
+                "chapters_total": {
+                    "type": "integer"
+                },
+                "complete": {
+                    "type": "boolean"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "failed": {
+                    "type": "boolean"
+                },
+                "phase": {
+                    "description": "Phase tracking (build -\u003e extract -\u003e classify -\u003e polish -\u003e finalize)",
+                    "type": "string"
+                },
+                "polish_failed": {
+                    "type": "integer"
+                },
+                "retries": {
+                    "type": "integer"
+                },
+                "started": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.SyncVoicesResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "synced": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.TTSConfigResponse": {
+            "type": "object",
+            "properties": {
+                "default_format": {
+                    "type": "string"
+                },
+                "default_voice": {
+                    "type": "string"
+                },
+                "formats": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "voice_cloning_url": {
+                    "type": "string"
+                },
+                "voices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.TTSVoice"
+                    }
+                }
+            }
+        },
+        "endpoints.TTSVoice": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "voice_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ToCEntry": {
+            "type": "object",
+            "properties": {
+                "actual_page_num": {
+                    "type": "integer"
+                },
+                "entry_number": {
+                    "type": "string"
+                },
+                "is_linked": {
+                    "type": "boolean"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "level_name": {
+                    "type": "string"
+                },
+                "printed_page_number": {
+                    "type": "string"
+                },
+                "sort_order": {
+                    "type": "integer"
+                },
+                "source": {
+                    "description": "\"extracted\" or \"discovered\"",
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ToCStatus": {
+            "type": "object",
+            "properties": {
+                "cost_usd": {
+                    "type": "number"
+                },
+                "discover_complete": {
+                    "description": "All entries discovered",
+                    "type": "boolean"
+                },
+                "end_page": {
+                    "type": "integer"
+                },
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ToCEntry"
+                    }
+                },
+                "entries_discovered": {
+                    "description": "Actually discovered (source=\"discovered\")",
+                    "type": "integer"
+                },
+                "entries_linked": {
+                    "type": "integer"
+                },
+                "entries_to_find": {
+                    "description": "From pattern analysis (how many should be discovered)",
+                    "type": "integer"
+                },
+                "entry_count": {
+                    "description": "Entries (when extracted)",
+                    "type": "integer"
+                },
+                "excluded_ranges": {
+                    "description": "Number of excluded page ranges",
+                    "type": "integer"
+                },
+                "extract_complete": {
+                    "type": "boolean"
+                },
+                "extract_failed": {
+                    "type": "boolean"
+                },
+                "extract_started": {
+                    "description": "Extract stage",
+                    "type": "boolean"
+                },
+                "finalize_complete": {
+                    "type": "boolean"
+                },
+                "finalize_failed": {
+                    "type": "boolean"
+                },
+                "finalize_retries": {
+                    "type": "integer"
+                },
+                "finalize_started": {
+                    "description": "Finalize stage (overall)",
+                    "type": "boolean"
+                },
+                "finder_complete": {
+                    "type": "boolean"
+                },
+                "finder_failed": {
+                    "type": "boolean"
+                },
+                "finder_started": {
+                    "description": "Finder stage",
+                    "type": "boolean"
+                },
+                "found": {
+                    "type": "boolean"
+                },
+                "link_complete": {
+                    "type": "boolean"
+                },
+                "link_failed": {
+                    "type": "boolean"
+                },
+                "link_retries": {
+                    "type": "integer"
+                },
+                "link_started": {
+                    "description": "Link stage",
+                    "type": "boolean"
+                },
+                "pattern_analysis": {
+                    "description": "Full pattern analysis result",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.PatternAnalysisResult"
+                        }
+                    ]
+                },
+                "pattern_complete": {
+                    "description": "Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation",
+                    "type": "boolean"
+                },
+                "patterns_found": {
+                    "description": "Number of patterns discovered",
+                    "type": "integer"
+                },
+                "start_page": {
+                    "type": "integer"
+                },
+                "validate_complete": {
+                    "description": "Gap validation done (same as FinalizeComplete for now)",
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.UpdateJobRequest": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.UpdateSettingRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "endpoints.VoiceResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "synced_at": {
+                    "type": "string"
+                },
+                "voice_id": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_jackzampolin_shelf_internal_config.Entry": {
             "type": "object",
             "properties": {
@@ -2954,1550 +4507,6 @@ const docTemplate = `{
                 },
                 "total_tokens": {
                     "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogDetailResponse": {
-            "type": "object",
-            "properties": {
-                "agent_type": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iterations": {
-                    "type": "integer"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "messages": {
-                    "description": "Detailed data",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "result": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                },
-                "tool_calls": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogSummary": {
-            "type": "object",
-            "properties": {
-                "agent_type": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iterations": {
-                    "type": "integer"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "agent_type": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iterations": {
-                    "type": "integer"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogsListResponse": {
-            "type": "object",
-            "properties": {
-                "logs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.AgentLogSummaryResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.AudioStatusResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "chapters": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterAudioStatus"
-                    }
-                },
-                "format": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "segment_count": {
-                    "type": "integer"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "total_cost_usd": {
-                    "type": "number"
-                },
-                "total_duration_ms": {
-                    "type": "integer"
-                },
-                "voice": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.Book": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "page_count": {
-                    "type": "integer"
-                },
-                "page_pattern_analysis_json": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.BookMetadata": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "authors": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "description": {
-                    "type": "string"
-                },
-                "isbn": {
-                    "type": "string"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "lccn": {
-                    "type": "string"
-                },
-                "publication_year": {
-                    "type": "integer"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "subjects": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.BookPromptResponse": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": "string"
-                },
-                "is_override": {
-                    "type": "boolean"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "variables": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.BookPromptsListResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "prompts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterAudioStatus": {
-            "type": "object",
-            "properties": {
-                "audio_file": {
-                    "type": "string"
-                },
-                "chapter_idx": {
-                    "type": "integer"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "download_url": {
-                    "type": "string"
-                },
-                "duration_ms": {
-                    "type": "integer"
-                },
-                "segment_count": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterPage": {
-            "type": "object",
-            "properties": {
-                "ocr_markdown": {
-                    "type": "string"
-                },
-                "page_num": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterParagraph": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "polished_text": {
-                    "type": "string"
-                },
-                "raw_text": {
-                    "type": "string"
-                },
-                "sort_order": {
-                    "type": "integer"
-                },
-                "start_page": {
-                    "type": "integer"
-                },
-                "word_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterWithText": {
-            "type": "object",
-            "properties": {
-                "classification_reasoning": {
-                    "type": "string"
-                },
-                "edits_applied_json": {
-                    "type": "string"
-                },
-                "end_page": {
-                    "type": "integer"
-                },
-                "entry_id": {
-                    "type": "string"
-                },
-                "entry_number": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "level": {
-                    "type": "integer"
-                },
-                "level_name": {
-                    "type": "string"
-                },
-                "matter_type": {
-                    "type": "string"
-                },
-                "page_count": {
-                    "type": "integer"
-                },
-                "pages": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterPage"
-                    }
-                },
-                "paragraphs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterParagraph"
-                    }
-                },
-                "polish_complete": {
-                    "type": "boolean"
-                },
-                "polish_failed": {
-                    "type": "boolean"
-                },
-                "polished_text": {
-                    "type": "string"
-                },
-                "sort_order": {
-                    "type": "integer"
-                },
-                "start_page": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "word_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ChaptersResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "book_title": {
-                    "type": "string"
-                },
-                "chapters": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterWithText"
-                    }
-                },
-                "has_chapters": {
-                    "type": "boolean"
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.CreateJobRequest": {
-            "type": "object",
-            "properties": {
-                "job_type": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                }
-            }
-        },
-        "internal_server_endpoints.CreateJobResponse": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.CreateVoiceRequest": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "voice_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.DefraStatus": {
-            "type": "object",
-            "properties": {
-                "container": {
-                    "type": "string"
-                },
-                "health": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.DetailedJobStatusResponse": {
-            "type": "object",
-            "properties": {
-                "agent_logs": {
-                    "description": "Agent logs summary",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.AgentLogSummary"
-                    }
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "description": "Metadata status",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.MetadataStatus"
-                        }
-                    ]
-                },
-                "ocr_progress": {
-                    "description": "Per-provider OCR progress",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/internal_server_endpoints.ProviderProgress"
-                    }
-                },
-                "stages": {
-                    "description": "Stage progress with costs",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.StageProgress"
-                        }
-                    ]
-                },
-                "structure": {
-                    "description": "Structure status (common-structure job)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.StructureStatus"
-                        }
-                    ]
-                },
-                "toc": {
-                    "description": "ToC status",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.ToCStatus"
-                        }
-                    ]
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.DiscoveredPattern": {
-            "type": "object",
-            "properties": {
-                "heading_format": {
-                    "type": "string"
-                },
-                "level": {
-                    "type": "integer"
-                },
-                "level_name": {
-                    "type": "string"
-                },
-                "pattern_type": {
-                    "type": "string"
-                },
-                "range_end": {
-                    "type": "string"
-                },
-                "range_start": {
-                    "type": "string"
-                },
-                "reasoning": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.EpubExportResponse": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "download_url": {
-                    "type": "string"
-                },
-                "file_path": {
-                    "type": "string"
-                },
-                "file_size": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ExcludedRange": {
-            "type": "object",
-            "properties": {
-                "end_page": {
-                    "type": "integer"
-                },
-                "reason": {
-                    "type": "string"
-                },
-                "start_page": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.GenerateAudioRequest": {
-            "type": "object",
-            "properties": {
-                "format": {
-                    "description": "Optional: output format (mp3, wav)",
-                    "type": "string"
-                },
-                "voice": {
-                    "description": "Optional: voice ID",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.GenerateAudioResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "chapters": {
-                    "type": "integer"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.GetJobResponse": {
-            "type": "object",
-            "properties": {
-                "_docID": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "job_type": {
-                    "type": "string"
-                },
-                "live_status": {
-                    "description": "Live status fields (only populated for running jobs)",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "pending_units": {
-                    "type": "integer"
-                },
-                "progress": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"
-                    }
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Status"
-                },
-                "worker_status": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.GetPageResponse": {
-            "type": "object",
-            "properties": {
-                "ocr_markdown": {
-                    "type": "string"
-                },
-                "ocr_results": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.OcrResult"
-                    }
-                },
-                "page_num": {
-                    "type": "integer"
-                },
-                "status": {
-                    "$ref": "#/definitions/internal_server_endpoints.PageStatus"
-                }
-            }
-        },
-        "internal_server_endpoints.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "defra": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.IngestRequest": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "pdf_paths": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.IngestResponse": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "process_job_id": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.JobStatusResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "is_complete": {
-                    "type": "boolean"
-                },
-                "job_type": {
-                    "type": "string"
-                },
-                "metadata_complete": {
-                    "type": "boolean"
-                },
-                "ocr_complete": {
-                    "type": "integer"
-                },
-                "toc_extracted": {
-                    "type": "boolean"
-                },
-                "toc_found": {
-                    "type": "boolean"
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.LLMCallCountsResponse": {
-            "type": "object",
-            "properties": {
-                "counts": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.LLMCallResponse": {
-            "type": "object",
-            "properties": {
-                "call": {
-                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
-                },
-                "error": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.LLMCallsResponse": {
-            "type": "object",
-            "properties": {
-                "calls": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ListBooksResponse": {
-            "type": "object",
-            "properties": {
-                "books": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.Book"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ListJobsResponse": {
-            "type": "object",
-            "properties": {
-                "jobs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Record"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ListMetricsResponse": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "metrics": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.Metric"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ListPagesResponse": {
-            "type": "object",
-            "properties": {
-                "pages": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.PageSummary"
-                    }
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ListVoicesResponse": {
-            "type": "object",
-            "properties": {
-                "voices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.VoiceResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.MetadataStatus": {
-            "type": "object",
-            "properties": {
-                "complete": {
-                    "type": "boolean"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "data": {
-                    "$ref": "#/definitions/internal_server_endpoints.BookMetadata"
-                },
-                "failed": {
-                    "type": "boolean"
-                },
-                "started": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.MetricsCostResponse": {
-            "type": "object",
-            "properties": {
-                "breakdown": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "number",
-                        "format": "float64"
-                    }
-                },
-                "total_cost_usd": {
-                    "type": "number"
-                }
-            }
-        },
-        "internal_server_endpoints.MetricsDetailedResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "stages": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.DetailedStats"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.MetricsSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "avg_cost_usd": {
-                    "type": "number"
-                },
-                "avg_time_seconds": {
-                    "type": "number"
-                },
-                "avg_tokens": {
-                    "type": "number"
-                },
-                "count": {
-                    "type": "integer"
-                },
-                "error_count": {
-                    "type": "integer"
-                },
-                "success_count": {
-                    "type": "integer"
-                },
-                "total_cost_usd": {
-                    "type": "number"
-                },
-                "total_time_seconds": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.OcrResult": {
-            "type": "object",
-            "properties": {
-                "confidence": {
-                    "type": "number"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.PageStatus": {
-            "type": "object",
-            "properties": {
-                "extract_complete": {
-                    "type": "boolean"
-                },
-                "ocr_complete": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.PageSummary": {
-            "type": "object",
-            "properties": {
-                "ocr_complete": {
-                    "type": "boolean"
-                },
-                "page_num": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.PatternAnalysisResult": {
-            "type": "object",
-            "properties": {
-                "excluded_ranges": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ExcludedRange"
-                    }
-                },
-                "patterns": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.DiscoveredPattern"
-                    }
-                },
-                "reasoning": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.PromptResponse": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "doc_id": {
-                    "type": "string"
-                },
-                "hash": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "variables": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.PromptsListResponse": {
-            "type": "object",
-            "properties": {
-                "prompts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.PromptResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ProviderProgress": {
-            "type": "object",
-            "properties": {
-                "complete": {
-                    "type": "integer"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ProvidersStatus": {
-            "type": "object",
-            "properties": {
-                "llm": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "ocr": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.RerunTocResponse": {
-            "type": "object",
-            "properties": {
-                "job_id": {
-                    "type": "string"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.SetPromptRequest": {
-            "type": "object",
-            "properties": {
-                "note": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.SettingResponse": {
-            "type": "object",
-            "properties": {
-                "entry": {
-                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
-                },
-                "error": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.SettingsResponse": {
-            "type": "object",
-            "properties": {
-                "settings": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.StageProgress": {
-            "type": "object",
-            "properties": {
-                "ocr": {
-                    "type": "object",
-                    "properties": {
-                        "complete": {
-                            "type": "integer"
-                        },
-                        "cost_by_provider": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "number",
-                                "format": "float64"
-                            }
-                        },
-                        "total": {
-                            "type": "integer"
-                        },
-                        "total_cost_usd": {
-                            "type": "number"
-                        }
-                    }
-                },
-                "pattern_analysis": {
-                    "type": "object",
-                    "properties": {
-                        "complete": {
-                            "type": "boolean"
-                        },
-                        "cost_usd": {
-                            "type": "number"
-                        }
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.StartJobRequest": {
-            "type": "object",
-            "properties": {
-                "force": {
-                    "description": "Optional: force restart even if already complete",
-                    "type": "boolean"
-                },
-                "job_type": {
-                    "description": "Optional: defaults to \"process-book\"",
-                    "type": "string"
-                },
-                "reset_from": {
-                    "description": "Optional: reset this operation and downstream deps before starting",
-                    "type": "string"
-                },
-                "variant": {
-                    "description": "Optional: pipeline variant (standard, photo-book, text-only, ocr-only)",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.StartJobResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "job_type": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.StatusResponse": {
-            "type": "object",
-            "properties": {
-                "defra": {
-                    "$ref": "#/definitions/internal_server_endpoints.DefraStatus"
-                },
-                "providers": {
-                    "$ref": "#/definitions/internal_server_endpoints.ProvidersStatus"
-                },
-                "server": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.StorytellerExportResponse": {
-            "type": "object",
-            "properties": {
-                "audio_chapters": {
-                    "type": "integer"
-                },
-                "author": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "download_url": {
-                    "type": "string"
-                },
-                "file_path": {
-                    "type": "string"
-                },
-                "file_size": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "total_duration_ms": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.StructureStatus": {
-            "type": "object",
-            "properties": {
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "chapters_extracted": {
-                    "type": "integer"
-                },
-                "chapters_polished": {
-                    "type": "integer"
-                },
-                "chapters_total": {
-                    "type": "integer"
-                },
-                "complete": {
-                    "type": "boolean"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "failed": {
-                    "type": "boolean"
-                },
-                "phase": {
-                    "description": "Phase tracking (build -\u003e extract -\u003e classify -\u003e polish -\u003e finalize)",
-                    "type": "string"
-                },
-                "polish_failed": {
-                    "type": "integer"
-                },
-                "retries": {
-                    "type": "integer"
-                },
-                "started": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.SyncVoicesResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "synced": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.TTSConfigResponse": {
-            "type": "object",
-            "properties": {
-                "default_format": {
-                    "type": "string"
-                },
-                "default_voice": {
-                    "type": "string"
-                },
-                "formats": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "model": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "voice_cloning_url": {
-                    "type": "string"
-                },
-                "voices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.TTSVoice"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.TTSVoice": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "voice_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ToCEntry": {
-            "type": "object",
-            "properties": {
-                "actual_page_num": {
-                    "type": "integer"
-                },
-                "entry_number": {
-                    "type": "string"
-                },
-                "is_linked": {
-                    "type": "boolean"
-                },
-                "level": {
-                    "type": "integer"
-                },
-                "level_name": {
-                    "type": "string"
-                },
-                "printed_page_number": {
-                    "type": "string"
-                },
-                "sort_order": {
-                    "type": "integer"
-                },
-                "source": {
-                    "description": "\"extracted\" or \"discovered\"",
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ToCStatus": {
-            "type": "object",
-            "properties": {
-                "cost_usd": {
-                    "type": "number"
-                },
-                "discover_complete": {
-                    "description": "All entries discovered",
-                    "type": "boolean"
-                },
-                "end_page": {
-                    "type": "integer"
-                },
-                "entries": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ToCEntry"
-                    }
-                },
-                "entries_discovered": {
-                    "description": "Actually discovered (source=\"discovered\")",
-                    "type": "integer"
-                },
-                "entries_linked": {
-                    "type": "integer"
-                },
-                "entries_to_find": {
-                    "description": "From pattern analysis (how many should be discovered)",
-                    "type": "integer"
-                },
-                "entry_count": {
-                    "description": "Entries (when extracted)",
-                    "type": "integer"
-                },
-                "excluded_ranges": {
-                    "description": "Number of excluded page ranges",
-                    "type": "integer"
-                },
-                "extract_complete": {
-                    "type": "boolean"
-                },
-                "extract_failed": {
-                    "type": "boolean"
-                },
-                "extract_started": {
-                    "description": "Extract stage",
-                    "type": "boolean"
-                },
-                "finalize_complete": {
-                    "type": "boolean"
-                },
-                "finalize_failed": {
-                    "type": "boolean"
-                },
-                "finalize_retries": {
-                    "type": "integer"
-                },
-                "finalize_started": {
-                    "description": "Finalize stage (overall)",
-                    "type": "boolean"
-                },
-                "finder_complete": {
-                    "type": "boolean"
-                },
-                "finder_failed": {
-                    "type": "boolean"
-                },
-                "finder_started": {
-                    "description": "Finder stage",
-                    "type": "boolean"
-                },
-                "found": {
-                    "type": "boolean"
-                },
-                "link_complete": {
-                    "type": "boolean"
-                },
-                "link_failed": {
-                    "type": "boolean"
-                },
-                "link_retries": {
-                    "type": "integer"
-                },
-                "link_started": {
-                    "description": "Link stage",
-                    "type": "boolean"
-                },
-                "pattern_analysis": {
-                    "description": "Full pattern analysis result",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.PatternAnalysisResult"
-                        }
-                    ]
-                },
-                "pattern_complete": {
-                    "description": "Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation",
-                    "type": "boolean"
-                },
-                "patterns_found": {
-                    "description": "Number of patterns discovered",
-                    "type": "integer"
-                },
-                "start_page": {
-                    "type": "integer"
-                },
-                "validate_complete": {
-                    "description": "Gap validation done (same as FinalizeComplete for now)",
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.UpdateJobRequest": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.UpdateSettingRequest": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "value": {}
-            }
-        },
-        "internal_server_endpoints.VoiceResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "is_default": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "synced_at": {
-                    "type": "string"
-                },
-                "voice_id": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -38,7 +38,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.AgentLogDetailResponse"
+                                    "$ref": "#/components/schemas/endpoints.AgentLogDetailResponse"
                                 }
                             }
                         }
@@ -48,7 +48,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -58,7 +58,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -68,7 +68,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -78,7 +78,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -99,7 +99,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ListBooksResponse"
+                                    "$ref": "#/components/schemas/endpoints.ListBooksResponse"
                                 }
                             }
                         }
@@ -109,7 +109,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -119,7 +119,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -138,7 +138,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.IngestRequest"
+                                "$ref": "#/components/schemas/endpoints.IngestRequest"
                             }
                         }
                     },
@@ -151,7 +151,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.IngestResponse"
+                                    "$ref": "#/components/schemas/endpoints.IngestResponse"
                                 }
                             }
                         }
@@ -161,7 +161,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -171,7 +171,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -181,7 +181,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -234,7 +234,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.IngestResponse"
+                                    "$ref": "#/components/schemas/endpoints.IngestResponse"
                                 }
                             }
                         }
@@ -244,7 +244,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -254,7 +254,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -264,7 +264,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -320,7 +320,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.AgentLogsListResponse"
+                                    "$ref": "#/components/schemas/endpoints.AgentLogsListResponse"
                                 }
                             }
                         }
@@ -330,7 +330,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -340,7 +340,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -350,7 +350,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -383,7 +383,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.AudioStatusResponse"
+                                    "$ref": "#/components/schemas/endpoints.AudioStatusResponse"
                                 }
                             }
                         }
@@ -393,7 +393,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -403,7 +403,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -413,7 +413,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -466,7 +466,7 @@
                         "content": {
                             "audio/mpeg": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -476,7 +476,7 @@
                         "content": {
                             "audio/mpeg": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -509,7 +509,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.EpubExportResponse"
+                                    "$ref": "#/components/schemas/endpoints.EpubExportResponse"
                                 }
                             }
                         }
@@ -519,7 +519,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -529,7 +529,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -539,7 +539,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -583,7 +583,7 @@
                         "content": {
                             "application/epub+zip": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -593,7 +593,7 @@
                         "content": {
                             "application/epub+zip": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -627,7 +627,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.StorytellerExportResponse"
+                                    "$ref": "#/components/schemas/endpoints.StorytellerExportResponse"
                                 }
                             }
                         }
@@ -637,7 +637,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -647,7 +647,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -657,7 +657,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -702,7 +702,7 @@
                         "content": {
                             "application/epub+zip": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -712,7 +712,7 @@
                         "content": {
                             "application/epub+zip": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -743,7 +743,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.GenerateAudioRequest"
+                                "$ref": "#/components/schemas/endpoints.GenerateAudioRequest"
                             }
                         }
                     },
@@ -755,7 +755,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.GenerateAudioResponse"
+                                    "$ref": "#/components/schemas/endpoints.GenerateAudioResponse"
                                 }
                             }
                         }
@@ -765,7 +765,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -775,7 +775,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -785,7 +785,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -795,7 +795,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -827,7 +827,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ListPagesResponse"
+                                    "$ref": "#/components/schemas/endpoints.ListPagesResponse"
                                 }
                             }
                         }
@@ -837,7 +837,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -847,7 +847,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -857,7 +857,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -898,7 +898,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.GetPageResponse"
+                                    "$ref": "#/components/schemas/endpoints.GetPageResponse"
                                 }
                             }
                         }
@@ -908,7 +908,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -918,7 +918,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -928,7 +928,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -938,7 +938,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -990,7 +990,7 @@
                         "content": {
                             "image/png": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1000,7 +1000,7 @@
                         "content": {
                             "image/png": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1010,7 +1010,7 @@
                         "content": {
                             "image/png": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1042,7 +1042,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.RerunTocResponse"
+                                    "$ref": "#/components/schemas/endpoints.RerunTocResponse"
                                 }
                             }
                         }
@@ -1052,7 +1052,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1062,7 +1062,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1072,7 +1072,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1082,7 +1082,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1092,7 +1092,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1124,7 +1124,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.Book"
+                                    "$ref": "#/components/schemas/endpoints.Book"
                                 }
                             }
                         }
@@ -1134,7 +1134,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1144,7 +1144,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1154,7 +1154,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1164,7 +1164,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1212,7 +1212,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ChaptersResponse"
+                                    "$ref": "#/components/schemas/endpoints.ChaptersResponse"
                                 }
                             }
                         }
@@ -1222,7 +1222,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1232,7 +1232,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1242,7 +1242,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1282,7 +1282,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.MetricsCostResponse"
+                                    "$ref": "#/components/schemas/endpoints.MetricsCostResponse"
                                 }
                             }
                         }
@@ -1292,7 +1292,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1302,7 +1302,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1312,7 +1312,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1345,7 +1345,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.MetricsDetailedResponse"
+                                    "$ref": "#/components/schemas/endpoints.MetricsDetailedResponse"
                                 }
                             }
                         }
@@ -1355,7 +1355,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1365,7 +1365,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1375,7 +1375,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1407,7 +1407,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.BookPromptsListResponse"
+                                    "$ref": "#/components/schemas/endpoints.BookPromptsListResponse"
                                 }
                             }
                         }
@@ -1417,7 +1417,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1458,7 +1458,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.BookPromptResponse"
+                                    "$ref": "#/components/schemas/endpoints.BookPromptResponse"
                                 }
                             }
                         }
@@ -1468,7 +1468,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1478,7 +1478,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1515,7 +1515,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.SetPromptRequest"
+                                "$ref": "#/components/schemas/endpoints.SetPromptRequest"
                             }
                         }
                     },
@@ -1528,7 +1528,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.BookPromptResponse"
+                                    "$ref": "#/components/schemas/endpoints.BookPromptResponse"
                                 }
                             }
                         }
@@ -1538,7 +1538,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1548,7 +1548,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1587,7 +1587,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.BookPromptResponse"
+                                    "$ref": "#/components/schemas/endpoints.BookPromptResponse"
                                 }
                             }
                         }
@@ -1597,7 +1597,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1607,7 +1607,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1628,7 +1628,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.HealthResponse"
+                                    "$ref": "#/components/schemas/endpoints.HealthResponse"
                                 }
                             }
                         }
@@ -1675,7 +1675,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ListJobsResponse"
+                                    "$ref": "#/components/schemas/endpoints.ListJobsResponse"
                                 }
                             }
                         }
@@ -1685,7 +1685,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1695,7 +1695,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1712,7 +1712,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.CreateJobRequest"
+                                "$ref": "#/components/schemas/endpoints.CreateJobRequest"
                             }
                         }
                     },
@@ -1725,7 +1725,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.CreateJobResponse"
+                                    "$ref": "#/components/schemas/endpoints.CreateJobResponse"
                                 }
                             }
                         }
@@ -1735,7 +1735,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1745,7 +1745,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1755,7 +1755,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1785,7 +1785,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.StartJobRequest"
+                                "$ref": "#/components/schemas/endpoints.StartJobRequest"
                             }
                         }
                     },
@@ -1797,7 +1797,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.StartJobResponse"
+                                    "$ref": "#/components/schemas/endpoints.StartJobResponse"
                                 }
                             }
                         }
@@ -1807,7 +1807,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1817,7 +1817,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1827,7 +1827,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1867,7 +1867,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.JobStatusResponse"
+                                    "$ref": "#/components/schemas/endpoints.JobStatusResponse"
                                 }
                             }
                         }
@@ -1877,7 +1877,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1887,7 +1887,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1897,7 +1897,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1929,7 +1929,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.DetailedJobStatusResponse"
+                                    "$ref": "#/components/schemas/endpoints.DetailedJobStatusResponse"
                                 }
                             }
                         }
@@ -1939,7 +1939,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1949,7 +1949,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1959,7 +1959,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -1991,7 +1991,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.GetJobResponse"
+                                    "$ref": "#/components/schemas/endpoints.GetJobResponse"
                                 }
                             }
                         }
@@ -2001,7 +2001,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2011,7 +2011,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2021,7 +2021,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2031,7 +2031,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2064,7 +2064,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2074,7 +2074,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2084,7 +2084,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2094,7 +2094,7 @@
                         "content": {
                             "*/*": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2122,7 +2122,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.UpdateJobRequest"
+                                "$ref": "#/components/schemas/endpoints.UpdateJobRequest"
                             }
                         }
                     },
@@ -2145,7 +2145,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2155,7 +2155,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2165,7 +2165,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2276,7 +2276,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.LLMCallsResponse"
+                                    "$ref": "#/components/schemas/endpoints.LLMCallsResponse"
                                 }
                             }
                         }
@@ -2286,7 +2286,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2296,7 +2296,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2328,7 +2328,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.LLMCallCountsResponse"
+                                    "$ref": "#/components/schemas/endpoints.LLMCallCountsResponse"
                                 }
                             }
                         }
@@ -2338,7 +2338,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2370,7 +2370,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.LLMCallResponse"
+                                    "$ref": "#/components/schemas/endpoints.LLMCallResponse"
                                 }
                             }
                         }
@@ -2380,7 +2380,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2390,7 +2390,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2461,7 +2461,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ListMetricsResponse"
+                                    "$ref": "#/components/schemas/endpoints.ListMetricsResponse"
                                 }
                             }
                         }
@@ -2471,7 +2471,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2481,7 +2481,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2552,7 +2552,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.MetricsCostResponse"
+                                    "$ref": "#/components/schemas/endpoints.MetricsCostResponse"
                                 }
                             }
                         }
@@ -2562,7 +2562,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2572,7 +2572,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2603,7 +2603,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.MetricsDetailedResponse"
+                                    "$ref": "#/components/schemas/endpoints.MetricsDetailedResponse"
                                 }
                             }
                         }
@@ -2613,7 +2613,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2623,7 +2623,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2686,7 +2686,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.MetricsSummaryResponse"
+                                    "$ref": "#/components/schemas/endpoints.MetricsSummaryResponse"
                                 }
                             }
                         }
@@ -2696,7 +2696,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2706,7 +2706,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2727,7 +2727,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.PromptsListResponse"
+                                    "$ref": "#/components/schemas/endpoints.PromptsListResponse"
                                 }
                             }
                         }
@@ -2737,7 +2737,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2769,7 +2769,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.PromptResponse"
+                                    "$ref": "#/components/schemas/endpoints.PromptResponse"
                                 }
                             }
                         }
@@ -2779,7 +2779,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2789,7 +2789,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2810,7 +2810,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.HealthResponse"
+                                    "$ref": "#/components/schemas/endpoints.HealthResponse"
                                 }
                             }
                         }
@@ -2820,7 +2820,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.HealthResponse"
+                                    "$ref": "#/components/schemas/endpoints.HealthResponse"
                                 }
                             }
                         }
@@ -2841,7 +2841,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.SettingsResponse"
+                                    "$ref": "#/components/schemas/endpoints.SettingsResponse"
                                 }
                             }
                         }
@@ -2851,7 +2851,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2883,7 +2883,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.SettingResponse"
+                                    "$ref": "#/components/schemas/endpoints.SettingResponse"
                                 }
                             }
                         }
@@ -2893,7 +2893,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2903,7 +2903,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2913,7 +2913,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2945,7 +2945,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.SettingResponse"
+                                    "$ref": "#/components/schemas/endpoints.SettingResponse"
                                 }
                             }
                         }
@@ -2955,7 +2955,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2965,7 +2965,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -2993,7 +2993,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.UpdateSettingRequest"
+                                "$ref": "#/components/schemas/endpoints.UpdateSettingRequest"
                             }
                         }
                     },
@@ -3006,7 +3006,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.SettingResponse"
+                                    "$ref": "#/components/schemas/endpoints.SettingResponse"
                                 }
                             }
                         }
@@ -3016,7 +3016,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3026,7 +3026,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3047,7 +3047,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.StatusResponse"
+                                    "$ref": "#/components/schemas/endpoints.StatusResponse"
                                 }
                             }
                         }
@@ -3068,7 +3068,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.TTSConfigResponse"
+                                    "$ref": "#/components/schemas/endpoints.TTSConfigResponse"
                                 }
                             }
                         }
@@ -3078,7 +3078,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3088,7 +3088,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3109,7 +3109,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ListVoicesResponse"
+                                    "$ref": "#/components/schemas/endpoints.ListVoicesResponse"
                                 }
                             }
                         }
@@ -3119,7 +3119,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3136,7 +3136,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/internal_server_endpoints.CreateVoiceRequest"
+                                "$ref": "#/components/schemas/endpoints.CreateVoiceRequest"
                             }
                         }
                     },
@@ -3149,7 +3149,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.VoiceResponse"
+                                    "$ref": "#/components/schemas/endpoints.VoiceResponse"
                                 }
                             }
                         }
@@ -3159,7 +3159,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3169,7 +3169,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3190,7 +3190,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.SyncVoicesResponse"
+                                    "$ref": "#/components/schemas/endpoints.SyncVoicesResponse"
                                 }
                             }
                         }
@@ -3200,7 +3200,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3245,7 +3245,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3255,7 +3255,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3300,7 +3300,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3310,7 +3310,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3320,7 +3320,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/internal_server_endpoints.ErrorResponse"
+                                    "$ref": "#/components/schemas/endpoints.ErrorResponse"
                                 }
                             }
                         }
@@ -3336,6 +3336,1559 @@
     ],
     "components": {
         "schemas": {
+            "endpoints.AgentLogDetailResponse": {
+                "type": "object",
+                "properties": {
+                    "agent_type": {
+                        "type": "string"
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "completed_at": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "iterations": {
+                        "type": "integer"
+                    },
+                    "job_id": {
+                        "type": "string"
+                    },
+                    "messages": {
+                        "description": "Detailed data",
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "result": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "started_at": {
+                        "type": "string"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "tool_calls": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            },
+            "endpoints.AgentLogSummary": {
+                "type": "object",
+                "properties": {
+                    "agent_type": {
+                        "type": "string"
+                    },
+                    "completed_at": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "iterations": {
+                        "type": "integer"
+                    },
+                    "started_at": {
+                        "type": "string"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "endpoints.AgentLogSummaryResponse": {
+                "type": "object",
+                "properties": {
+                    "agent_type": {
+                        "type": "string"
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "completed_at": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "iterations": {
+                        "type": "integer"
+                    },
+                    "job_id": {
+                        "type": "string"
+                    },
+                    "started_at": {
+                        "type": "string"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "endpoints.AgentLogsListResponse": {
+                "type": "object",
+                "properties": {
+                    "logs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.AgentLogSummaryResponse"
+                        }
+                    }
+                }
+            },
+            "endpoints.AudioStatusResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "chapter_count": {
+                        "type": "integer"
+                    },
+                    "chapters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.ChapterAudioStatus"
+                        }
+                    },
+                    "format": {
+                        "type": "string"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "segment_count": {
+                        "type": "integer"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "total_cost_usd": {
+                        "type": "number"
+                    },
+                    "total_duration_ms": {
+                        "type": "integer"
+                    },
+                    "voice": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.Book": {
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "page_count": {
+                        "type": "integer"
+                    },
+                    "page_pattern_analysis_json": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.BookMetadata": {
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "authors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "isbn": {
+                        "type": "string"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "lccn": {
+                        "type": "string"
+                    },
+                    "publication_year": {
+                        "type": "integer"
+                    },
+                    "publisher": {
+                        "type": "string"
+                    },
+                    "subjects": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.BookPromptResponse": {
+                "type": "object",
+                "properties": {
+                    "cid": {
+                        "type": "string"
+                    },
+                    "is_override": {
+                        "type": "boolean"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    },
+                    "variables": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "endpoints.BookPromptsListResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "prompts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.BookPromptResponse"
+                        }
+                    }
+                }
+            },
+            "endpoints.ChapterAudioStatus": {
+                "type": "object",
+                "properties": {
+                    "audio_file": {
+                        "type": "string"
+                    },
+                    "chapter_idx": {
+                        "type": "integer"
+                    },
+                    "cost_usd": {
+                        "type": "number"
+                    },
+                    "download_url": {
+                        "type": "string"
+                    },
+                    "duration_ms": {
+                        "type": "integer"
+                    },
+                    "segment_count": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.ChapterPage": {
+                "type": "object",
+                "properties": {
+                    "ocr_markdown": {
+                        "type": "string"
+                    },
+                    "page_num": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.ChapterParagraph": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "polished_text": {
+                        "type": "string"
+                    },
+                    "raw_text": {
+                        "type": "string"
+                    },
+                    "sort_order": {
+                        "type": "integer"
+                    },
+                    "start_page": {
+                        "type": "integer"
+                    },
+                    "word_count": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.ChapterWithText": {
+                "type": "object",
+                "properties": {
+                    "audio_include": {
+                        "type": "boolean"
+                    },
+                    "audio_include_reasoning": {
+                        "type": "string"
+                    },
+                    "classification_reasoning": {
+                        "type": "string"
+                    },
+                    "content_type": {
+                        "type": "string"
+                    },
+                    "edits_applied_json": {
+                        "type": "string"
+                    },
+                    "end_page": {
+                        "type": "integer"
+                    },
+                    "entry_id": {
+                        "type": "string"
+                    },
+                    "entry_number": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "level": {
+                        "type": "integer"
+                    },
+                    "level_name": {
+                        "type": "string"
+                    },
+                    "matter_type": {
+                        "type": "string"
+                    },
+                    "page_count": {
+                        "type": "integer"
+                    },
+                    "pages": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.ChapterPage"
+                        }
+                    },
+                    "paragraphs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.ChapterParagraph"
+                        }
+                    },
+                    "polish_complete": {
+                        "type": "boolean"
+                    },
+                    "polish_failed": {
+                        "type": "boolean"
+                    },
+                    "polished_text": {
+                        "type": "string"
+                    },
+                    "sort_order": {
+                        "type": "integer"
+                    },
+                    "start_page": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "word_count": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.ChaptersResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "book_title": {
+                        "type": "string"
+                    },
+                    "chapters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.ChapterWithText"
+                        }
+                    },
+                    "has_chapters": {
+                        "type": "boolean"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.CreateJobRequest": {
+                "type": "object",
+                "properties": {
+                    "job_type": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    }
+                }
+            },
+            "endpoints.CreateJobResponse": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.CreateVoiceRequest": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "voice_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.DefraStatus": {
+                "type": "object",
+                "properties": {
+                    "container": {
+                        "type": "string"
+                    },
+                    "health": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.DetailedJobStatusResponse": {
+                "type": "object",
+                "properties": {
+                    "agent_logs": {
+                        "description": "Agent logs summary",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.AgentLogSummary"
+                        }
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "description": "Metadata status",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/endpoints.MetadataStatus"
+                            }
+                        ]
+                    },
+                    "ocr_progress": {
+                        "description": "Per-provider OCR progress",
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/endpoints.ProviderProgress"
+                        }
+                    },
+                    "stages": {
+                        "description": "Stage progress with costs",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/endpoints.StageProgress"
+                            }
+                        ]
+                    },
+                    "structure": {
+                        "description": "Structure status (common-structure job)",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/endpoints.StructureStatus"
+                            }
+                        ]
+                    },
+                    "toc": {
+                        "description": "ToC status",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/endpoints.ToCStatus"
+                            }
+                        ]
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.DiscoveredPattern": {
+                "type": "object",
+                "properties": {
+                    "heading_format": {
+                        "type": "string"
+                    },
+                    "level": {
+                        "type": "integer"
+                    },
+                    "level_name": {
+                        "type": "string"
+                    },
+                    "pattern_type": {
+                        "type": "string"
+                    },
+                    "range_end": {
+                        "type": "string"
+                    },
+                    "range_start": {
+                        "type": "string"
+                    },
+                    "reasoning": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.EpubExportResponse": {
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "chapter_count": {
+                        "type": "integer"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "download_url": {
+                        "type": "string"
+                    },
+                    "file_path": {
+                        "type": "string"
+                    },
+                    "file_size": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.ErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.ExcludedRange": {
+                "type": "object",
+                "properties": {
+                    "end_page": {
+                        "type": "integer"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "start_page": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.GenerateAudioRequest": {
+                "type": "object",
+                "properties": {
+                    "format": {
+                        "description": "Optional: output format (mp3, wav)",
+                        "type": "string"
+                    },
+                    "voice": {
+                        "description": "Optional: voice ID",
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.GenerateAudioResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "chapters": {
+                        "type": "integer"
+                    },
+                    "job_id": {
+                        "type": "string"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.GetJobResponse": {
+                "type": "object",
+                "properties": {
+                    "_docID": {
+                        "type": "string"
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "completed_at": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "job_type": {
+                        "type": "string"
+                    },
+                    "live_status": {
+                        "description": "Live status fields (only populated for running jobs)",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    },
+                    "pending_units": {
+                        "type": "integer"
+                    },
+                    "progress": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"
+                        }
+                    },
+                    "started_at": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.Status"
+                    },
+                    "worker_status": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"
+                        }
+                    }
+                }
+            },
+            "endpoints.GetPageResponse": {
+                "type": "object",
+                "properties": {
+                    "ocr_markdown": {
+                        "type": "string"
+                    },
+                    "ocr_results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.OcrResult"
+                        }
+                    },
+                    "page_num": {
+                        "type": "integer"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/endpoints.PageStatus"
+                    }
+                }
+            },
+            "endpoints.HealthResponse": {
+                "type": "object",
+                "properties": {
+                    "defra": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.IngestRequest": {
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "pdf_paths": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.IngestResponse": {
+                "type": "object",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "job_id": {
+                        "type": "string"
+                    },
+                    "process_job_id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.JobStatusResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "is_complete": {
+                        "type": "boolean"
+                    },
+                    "job_type": {
+                        "type": "string"
+                    },
+                    "metadata_complete": {
+                        "type": "boolean"
+                    },
+                    "ocr_complete": {
+                        "type": "integer"
+                    },
+                    "toc_extracted": {
+                        "type": "boolean"
+                    },
+                    "toc_found": {
+                        "type": "boolean"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.LLMCallCountsResponse": {
+                "type": "object",
+                "properties": {
+                    "counts": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            },
+            "endpoints.LLMCallResponse": {
+                "type": "object",
+                "properties": {
+                    "call": {
+                        "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_llmcall.Call"
+                    },
+                    "error": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.LLMCallsResponse": {
+                "type": "object",
+                "properties": {
+                    "calls": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_llmcall.Call"
+                        }
+                    },
+                    "total": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.ListBooksResponse": {
+                "type": "object",
+                "properties": {
+                    "books": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.Book"
+                        }
+                    }
+                }
+            },
+            "endpoints.ListJobsResponse": {
+                "type": "object",
+                "properties": {
+                    "jobs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.Record"
+                        }
+                    }
+                }
+            },
+            "endpoints.ListMetricsResponse": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer"
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_metrics.Metric"
+                        }
+                    }
+                }
+            },
+            "endpoints.ListPagesResponse": {
+                "type": "object",
+                "properties": {
+                    "pages": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.PageSummary"
+                        }
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.ListVoicesResponse": {
+                "type": "object",
+                "properties": {
+                    "voices": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.VoiceResponse"
+                        }
+                    }
+                }
+            },
+            "endpoints.MetadataStatus": {
+                "type": "object",
+                "properties": {
+                    "complete": {
+                        "type": "boolean"
+                    },
+                    "cost_usd": {
+                        "type": "number"
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/endpoints.BookMetadata"
+                    },
+                    "failed": {
+                        "type": "boolean"
+                    },
+                    "started": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "endpoints.MetricsCostResponse": {
+                "type": "object",
+                "properties": {
+                    "breakdown": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "number",
+                            "format": "float64"
+                        }
+                    },
+                    "total_cost_usd": {
+                        "type": "number"
+                    }
+                }
+            },
+            "endpoints.MetricsDetailedResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "stages": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_metrics.DetailedStats"
+                        }
+                    }
+                }
+            },
+            "endpoints.MetricsSummaryResponse": {
+                "type": "object",
+                "properties": {
+                    "avg_cost_usd": {
+                        "type": "number"
+                    },
+                    "avg_time_seconds": {
+                        "type": "number"
+                    },
+                    "avg_tokens": {
+                        "type": "number"
+                    },
+                    "count": {
+                        "type": "integer"
+                    },
+                    "error_count": {
+                        "type": "integer"
+                    },
+                    "success_count": {
+                        "type": "integer"
+                    },
+                    "total_cost_usd": {
+                        "type": "number"
+                    },
+                    "total_time_seconds": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.OcrResult": {
+                "type": "object",
+                "properties": {
+                    "confidence": {
+                        "type": "number"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.PageStatus": {
+                "type": "object",
+                "properties": {
+                    "extract_complete": {
+                        "type": "boolean"
+                    },
+                    "ocr_complete": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "endpoints.PageSummary": {
+                "type": "object",
+                "properties": {
+                    "ocr_complete": {
+                        "type": "boolean"
+                    },
+                    "page_num": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.PatternAnalysisResult": {
+                "type": "object",
+                "properties": {
+                    "excluded_ranges": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.ExcludedRange"
+                        }
+                    },
+                    "patterns": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.DiscoveredPattern"
+                        }
+                    },
+                    "reasoning": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.PromptResponse": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "doc_id": {
+                        "type": "string"
+                    },
+                    "hash": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    },
+                    "variables": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "endpoints.PromptsListResponse": {
+                "type": "object",
+                "properties": {
+                    "prompts": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.PromptResponse"
+                        }
+                    }
+                }
+            },
+            "endpoints.ProviderProgress": {
+                "type": "object",
+                "properties": {
+                    "complete": {
+                        "type": "integer"
+                    },
+                    "cost_usd": {
+                        "type": "number"
+                    },
+                    "total": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.ProvidersStatus": {
+                "type": "object",
+                "properties": {
+                    "llm": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "ocr": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "endpoints.RerunTocResponse": {
+                "type": "object",
+                "properties": {
+                    "job_id": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.SetPromptRequest": {
+                "type": "object",
+                "properties": {
+                    "note": {
+                        "type": "string"
+                    },
+                    "text": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.SettingResponse": {
+                "type": "object",
+                "properties": {
+                    "entry": {
+                        "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_config.Entry"
+                    },
+                    "error": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.SettingsResponse": {
+                "type": "object",
+                "properties": {
+                    "settings": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_config.Entry"
+                        }
+                    }
+                }
+            },
+            "endpoints.StageProgress": {
+                "type": "object",
+                "properties": {
+                    "ocr": {
+                        "type": "object",
+                        "properties": {
+                            "complete": {
+                                "type": "integer"
+                            },
+                            "cost_by_provider": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "number",
+                                    "format": "float64"
+                                }
+                            },
+                            "total": {
+                                "type": "integer"
+                            },
+                            "total_cost_usd": {
+                                "type": "number"
+                            }
+                        }
+                    },
+                    "pattern_analysis": {
+                        "type": "object",
+                        "properties": {
+                            "complete": {
+                                "type": "boolean"
+                            },
+                            "cost_usd": {
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "endpoints.StartJobRequest": {
+                "type": "object",
+                "properties": {
+                    "force": {
+                        "description": "Optional: force restart even if already complete",
+                        "type": "boolean"
+                    },
+                    "job_type": {
+                        "description": "Optional: defaults to \"process-book\"",
+                        "type": "string"
+                    },
+                    "reset_from": {
+                        "description": "Optional: reset this operation and downstream deps before starting",
+                        "type": "string"
+                    },
+                    "variant": {
+                        "description": "Optional: pipeline variant (standard, photo-book, text-only, ocr-only)",
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.StartJobResponse": {
+                "type": "object",
+                "properties": {
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "job_id": {
+                        "type": "string"
+                    },
+                    "job_type": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.StatusResponse": {
+                "type": "object",
+                "properties": {
+                    "defra": {
+                        "$ref": "#/components/schemas/endpoints.DefraStatus"
+                    },
+                    "providers": {
+                        "$ref": "#/components/schemas/endpoints.ProvidersStatus"
+                    },
+                    "server": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.StorytellerExportResponse": {
+                "type": "object",
+                "properties": {
+                    "audio_chapters": {
+                        "type": "integer"
+                    },
+                    "author": {
+                        "type": "string"
+                    },
+                    "book_id": {
+                        "type": "string"
+                    },
+                    "chapter_count": {
+                        "type": "integer"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "download_url": {
+                        "type": "string"
+                    },
+                    "file_path": {
+                        "type": "string"
+                    },
+                    "file_size": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "total_duration_ms": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.StructureStatus": {
+                "type": "object",
+                "properties": {
+                    "chapter_count": {
+                        "type": "integer"
+                    },
+                    "chapters_extracted": {
+                        "type": "integer"
+                    },
+                    "chapters_polished": {
+                        "type": "integer"
+                    },
+                    "chapters_total": {
+                        "type": "integer"
+                    },
+                    "complete": {
+                        "type": "boolean"
+                    },
+                    "cost_usd": {
+                        "type": "number"
+                    },
+                    "failed": {
+                        "type": "boolean"
+                    },
+                    "phase": {
+                        "description": "Phase tracking (build -> extract -> classify -> polish -> finalize)",
+                        "type": "string"
+                    },
+                    "polish_failed": {
+                        "type": "integer"
+                    },
+                    "retries": {
+                        "type": "integer"
+                    },
+                    "started": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "endpoints.SyncVoicesResponse": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    },
+                    "synced": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "endpoints.TTSConfigResponse": {
+                "type": "object",
+                "properties": {
+                    "default_format": {
+                        "type": "string"
+                    },
+                    "default_voice": {
+                        "type": "string"
+                    },
+                    "formats": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "voice_cloning_url": {
+                        "type": "string"
+                    },
+                    "voices": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.TTSVoice"
+                        }
+                    }
+                }
+            },
+            "endpoints.TTSVoice": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "voice_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.ToCEntry": {
+                "type": "object",
+                "properties": {
+                    "actual_page_num": {
+                        "type": "integer"
+                    },
+                    "entry_number": {
+                        "type": "string"
+                    },
+                    "is_linked": {
+                        "type": "boolean"
+                    },
+                    "level": {
+                        "type": "integer"
+                    },
+                    "level_name": {
+                        "type": "string"
+                    },
+                    "printed_page_number": {
+                        "type": "string"
+                    },
+                    "sort_order": {
+                        "type": "integer"
+                    },
+                    "source": {
+                        "description": "\"extracted\" or \"discovered\"",
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.ToCStatus": {
+                "type": "object",
+                "properties": {
+                    "cost_usd": {
+                        "type": "number"
+                    },
+                    "discover_complete": {
+                        "description": "All entries discovered",
+                        "type": "boolean"
+                    },
+                    "end_page": {
+                        "type": "integer"
+                    },
+                    "entries": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/endpoints.ToCEntry"
+                        }
+                    },
+                    "entries_discovered": {
+                        "description": "Actually discovered (source=\"discovered\")",
+                        "type": "integer"
+                    },
+                    "entries_linked": {
+                        "type": "integer"
+                    },
+                    "entries_to_find": {
+                        "description": "From pattern analysis (how many should be discovered)",
+                        "type": "integer"
+                    },
+                    "entry_count": {
+                        "description": "Entries (when extracted)",
+                        "type": "integer"
+                    },
+                    "excluded_ranges": {
+                        "description": "Number of excluded page ranges",
+                        "type": "integer"
+                    },
+                    "extract_complete": {
+                        "type": "boolean"
+                    },
+                    "extract_failed": {
+                        "type": "boolean"
+                    },
+                    "extract_started": {
+                        "description": "Extract stage",
+                        "type": "boolean"
+                    },
+                    "finalize_complete": {
+                        "type": "boolean"
+                    },
+                    "finalize_failed": {
+                        "type": "boolean"
+                    },
+                    "finalize_retries": {
+                        "type": "integer"
+                    },
+                    "finalize_started": {
+                        "description": "Finalize stage (overall)",
+                        "type": "boolean"
+                    },
+                    "finder_complete": {
+                        "type": "boolean"
+                    },
+                    "finder_failed": {
+                        "type": "boolean"
+                    },
+                    "finder_started": {
+                        "description": "Finder stage",
+                        "type": "boolean"
+                    },
+                    "found": {
+                        "type": "boolean"
+                    },
+                    "link_complete": {
+                        "type": "boolean"
+                    },
+                    "link_failed": {
+                        "type": "boolean"
+                    },
+                    "link_retries": {
+                        "type": "integer"
+                    },
+                    "link_started": {
+                        "description": "Link stage",
+                        "type": "boolean"
+                    },
+                    "pattern_analysis": {
+                        "description": "Full pattern analysis result",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/endpoints.PatternAnalysisResult"
+                            }
+                        ]
+                    },
+                    "pattern_complete": {
+                        "description": "Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation",
+                        "type": "boolean"
+                    },
+                    "patterns_found": {
+                        "description": "Number of patterns discovered",
+                        "type": "integer"
+                    },
+                    "start_page": {
+                        "type": "integer"
+                    },
+                    "validate_complete": {
+                        "description": "Gap validation done (same as FinalizeComplete for now)",
+                        "type": "boolean"
+                    }
+                }
+            },
+            "endpoints.UpdateJobRequest": {
+                "type": "object",
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": {}
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "endpoints.UpdateSettingRequest": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "value": {}
+                }
+            },
+            "endpoints.VoiceResponse": {
+                "type": "object",
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "is_default": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "synced_at": {
+                        "type": "string"
+                    },
+                    "voice_id": {
+                        "type": "string"
+                    }
+                }
+            },
             "github_com_jackzampolin_shelf_internal_config.Entry": {
                 "type": "object",
                 "properties": {
@@ -3677,1550 +5230,6 @@
                     },
                     "total_tokens": {
                         "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.AgentLogDetailResponse": {
-                "type": "object",
-                "properties": {
-                    "agent_type": {
-                        "type": "string"
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "completed_at": {
-                        "type": "string"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "iterations": {
-                        "type": "integer"
-                    },
-                    "job_id": {
-                        "type": "string"
-                    },
-                    "messages": {
-                        "description": "Detailed data",
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    },
-                    "result": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    },
-                    "started_at": {
-                        "type": "string"
-                    },
-                    "success": {
-                        "type": "boolean"
-                    },
-                    "tool_calls": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.AgentLogSummary": {
-                "type": "object",
-                "properties": {
-                    "agent_type": {
-                        "type": "string"
-                    },
-                    "completed_at": {
-                        "type": "string"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "iterations": {
-                        "type": "integer"
-                    },
-                    "started_at": {
-                        "type": "string"
-                    },
-                    "success": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "internal_server_endpoints.AgentLogSummaryResponse": {
-                "type": "object",
-                "properties": {
-                    "agent_type": {
-                        "type": "string"
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "completed_at": {
-                        "type": "string"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "iterations": {
-                        "type": "integer"
-                    },
-                    "job_id": {
-                        "type": "string"
-                    },
-                    "started_at": {
-                        "type": "string"
-                    },
-                    "success": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "internal_server_endpoints.AgentLogsListResponse": {
-                "type": "object",
-                "properties": {
-                    "logs": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.AgentLogSummaryResponse"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.AudioStatusResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "chapter_count": {
-                        "type": "integer"
-                    },
-                    "chapters": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ChapterAudioStatus"
-                        }
-                    },
-                    "format": {
-                        "type": "string"
-                    },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "segment_count": {
-                        "type": "integer"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "total_cost_usd": {
-                        "type": "number"
-                    },
-                    "total_duration_ms": {
-                        "type": "integer"
-                    },
-                    "voice": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.Book": {
-                "type": "object",
-                "properties": {
-                    "author": {
-                        "type": "string"
-                    },
-                    "created_at": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "page_count": {
-                        "type": "integer"
-                    },
-                    "page_pattern_analysis_json": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.BookMetadata": {
-                "type": "object",
-                "properties": {
-                    "author": {
-                        "type": "string"
-                    },
-                    "authors": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "isbn": {
-                        "type": "string"
-                    },
-                    "language": {
-                        "type": "string"
-                    },
-                    "lccn": {
-                        "type": "string"
-                    },
-                    "publication_year": {
-                        "type": "integer"
-                    },
-                    "publisher": {
-                        "type": "string"
-                    },
-                    "subjects": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.BookPromptResponse": {
-                "type": "object",
-                "properties": {
-                    "cid": {
-                        "type": "string"
-                    },
-                    "is_override": {
-                        "type": "boolean"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "text": {
-                        "type": "string"
-                    },
-                    "variables": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.BookPromptsListResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "prompts": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.BookPromptResponse"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.ChapterAudioStatus": {
-                "type": "object",
-                "properties": {
-                    "audio_file": {
-                        "type": "string"
-                    },
-                    "chapter_idx": {
-                        "type": "integer"
-                    },
-                    "cost_usd": {
-                        "type": "number"
-                    },
-                    "download_url": {
-                        "type": "string"
-                    },
-                    "duration_ms": {
-                        "type": "integer"
-                    },
-                    "segment_count": {
-                        "type": "integer"
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.ChapterPage": {
-                "type": "object",
-                "properties": {
-                    "ocr_markdown": {
-                        "type": "string"
-                    },
-                    "page_num": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.ChapterParagraph": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "polished_text": {
-                        "type": "string"
-                    },
-                    "raw_text": {
-                        "type": "string"
-                    },
-                    "sort_order": {
-                        "type": "integer"
-                    },
-                    "start_page": {
-                        "type": "integer"
-                    },
-                    "word_count": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.ChapterWithText": {
-                "type": "object",
-                "properties": {
-                    "classification_reasoning": {
-                        "type": "string"
-                    },
-                    "edits_applied_json": {
-                        "type": "string"
-                    },
-                    "end_page": {
-                        "type": "integer"
-                    },
-                    "entry_id": {
-                        "type": "string"
-                    },
-                    "entry_number": {
-                        "type": "string"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "level": {
-                        "type": "integer"
-                    },
-                    "level_name": {
-                        "type": "string"
-                    },
-                    "matter_type": {
-                        "type": "string"
-                    },
-                    "page_count": {
-                        "type": "integer"
-                    },
-                    "pages": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ChapterPage"
-                        }
-                    },
-                    "paragraphs": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ChapterParagraph"
-                        }
-                    },
-                    "polish_complete": {
-                        "type": "boolean"
-                    },
-                    "polish_failed": {
-                        "type": "boolean"
-                    },
-                    "polished_text": {
-                        "type": "string"
-                    },
-                    "sort_order": {
-                        "type": "integer"
-                    },
-                    "start_page": {
-                        "type": "integer"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "word_count": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.ChaptersResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "book_title": {
-                        "type": "string"
-                    },
-                    "chapters": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ChapterWithText"
-                        }
-                    },
-                    "has_chapters": {
-                        "type": "boolean"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.CreateJobRequest": {
-                "type": "object",
-                "properties": {
-                    "job_type": {
-                        "type": "string"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "additionalProperties": {}
-                    }
-                }
-            },
-            "internal_server_endpoints.CreateJobResponse": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.CreateVoiceRequest": {
-                "type": "object",
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "voice_id": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.DefraStatus": {
-                "type": "object",
-                "properties": {
-                    "container": {
-                        "type": "string"
-                    },
-                    "health": {
-                        "type": "string"
-                    },
-                    "url": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.DetailedJobStatusResponse": {
-                "type": "object",
-                "properties": {
-                    "agent_logs": {
-                        "description": "Agent logs summary",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.AgentLogSummary"
-                        }
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "metadata": {
-                        "description": "Metadata status",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/internal_server_endpoints.MetadataStatus"
-                            }
-                        ]
-                    },
-                    "ocr_progress": {
-                        "description": "Per-provider OCR progress",
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ProviderProgress"
-                        }
-                    },
-                    "stages": {
-                        "description": "Stage progress with costs",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/internal_server_endpoints.StageProgress"
-                            }
-                        ]
-                    },
-                    "structure": {
-                        "description": "Structure status (common-structure job)",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/internal_server_endpoints.StructureStatus"
-                            }
-                        ]
-                    },
-                    "toc": {
-                        "description": "ToC status",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/internal_server_endpoints.ToCStatus"
-                            }
-                        ]
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.DiscoveredPattern": {
-                "type": "object",
-                "properties": {
-                    "heading_format": {
-                        "type": "string"
-                    },
-                    "level": {
-                        "type": "integer"
-                    },
-                    "level_name": {
-                        "type": "string"
-                    },
-                    "pattern_type": {
-                        "type": "string"
-                    },
-                    "range_end": {
-                        "type": "string"
-                    },
-                    "range_start": {
-                        "type": "string"
-                    },
-                    "reasoning": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.EpubExportResponse": {
-                "type": "object",
-                "properties": {
-                    "author": {
-                        "type": "string"
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "chapter_count": {
-                        "type": "integer"
-                    },
-                    "created_at": {
-                        "type": "string"
-                    },
-                    "download_url": {
-                        "type": "string"
-                    },
-                    "file_path": {
-                        "type": "string"
-                    },
-                    "file_size": {
-                        "type": "integer"
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.ErrorResponse": {
-                "type": "object",
-                "properties": {
-                    "error": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.ExcludedRange": {
-                "type": "object",
-                "properties": {
-                    "end_page": {
-                        "type": "integer"
-                    },
-                    "reason": {
-                        "type": "string"
-                    },
-                    "start_page": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.GenerateAudioRequest": {
-                "type": "object",
-                "properties": {
-                    "format": {
-                        "description": "Optional: output format (mp3, wav)",
-                        "type": "string"
-                    },
-                    "voice": {
-                        "description": "Optional: voice ID",
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.GenerateAudioResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "chapters": {
-                        "type": "integer"
-                    },
-                    "job_id": {
-                        "type": "string"
-                    },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.GetJobResponse": {
-                "type": "object",
-                "properties": {
-                    "_docID": {
-                        "type": "string"
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "completed_at": {
-                        "type": "string"
-                    },
-                    "created_at": {
-                        "type": "string"
-                    },
-                    "error": {
-                        "type": "string"
-                    },
-                    "job_type": {
-                        "type": "string"
-                    },
-                    "live_status": {
-                        "description": "Live status fields (only populated for running jobs)",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "additionalProperties": {}
-                    },
-                    "pending_units": {
-                        "type": "integer"
-                    },
-                    "progress": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"
-                        }
-                    },
-                    "started_at": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.Status"
-                    },
-                    "worker_status": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.GetPageResponse": {
-                "type": "object",
-                "properties": {
-                    "ocr_markdown": {
-                        "type": "string"
-                    },
-                    "ocr_results": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.OcrResult"
-                        }
-                    },
-                    "page_num": {
-                        "type": "integer"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/internal_server_endpoints.PageStatus"
-                    }
-                }
-            },
-            "internal_server_endpoints.HealthResponse": {
-                "type": "object",
-                "properties": {
-                    "defra": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.IngestRequest": {
-                "type": "object",
-                "properties": {
-                    "author": {
-                        "type": "string"
-                    },
-                    "pdf_paths": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.IngestResponse": {
-                "type": "object",
-                "properties": {
-                    "author": {
-                        "type": "string"
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "job_id": {
-                        "type": "string"
-                    },
-                    "process_job_id": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.JobStatusResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "is_complete": {
-                        "type": "boolean"
-                    },
-                    "job_type": {
-                        "type": "string"
-                    },
-                    "metadata_complete": {
-                        "type": "boolean"
-                    },
-                    "ocr_complete": {
-                        "type": "integer"
-                    },
-                    "toc_extracted": {
-                        "type": "boolean"
-                    },
-                    "toc_found": {
-                        "type": "boolean"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.LLMCallCountsResponse": {
-                "type": "object",
-                "properties": {
-                    "counts": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.LLMCallResponse": {
-                "type": "object",
-                "properties": {
-                    "call": {
-                        "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_llmcall.Call"
-                    },
-                    "error": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.LLMCallsResponse": {
-                "type": "object",
-                "properties": {
-                    "calls": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_llmcall.Call"
-                        }
-                    },
-                    "total": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.ListBooksResponse": {
-                "type": "object",
-                "properties": {
-                    "books": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.Book"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.ListJobsResponse": {
-                "type": "object",
-                "properties": {
-                    "jobs": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_jobs.Record"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.ListMetricsResponse": {
-                "type": "object",
-                "properties": {
-                    "count": {
-                        "type": "integer"
-                    },
-                    "metrics": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_metrics.Metric"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.ListPagesResponse": {
-                "type": "object",
-                "properties": {
-                    "pages": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.PageSummary"
-                        }
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.ListVoicesResponse": {
-                "type": "object",
-                "properties": {
-                    "voices": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.VoiceResponse"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.MetadataStatus": {
-                "type": "object",
-                "properties": {
-                    "complete": {
-                        "type": "boolean"
-                    },
-                    "cost_usd": {
-                        "type": "number"
-                    },
-                    "data": {
-                        "$ref": "#/components/schemas/internal_server_endpoints.BookMetadata"
-                    },
-                    "failed": {
-                        "type": "boolean"
-                    },
-                    "started": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "internal_server_endpoints.MetricsCostResponse": {
-                "type": "object",
-                "properties": {
-                    "breakdown": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "number",
-                            "format": "float64"
-                        }
-                    },
-                    "total_cost_usd": {
-                        "type": "number"
-                    }
-                }
-            },
-            "internal_server_endpoints.MetricsDetailedResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "stages": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_metrics.DetailedStats"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.MetricsSummaryResponse": {
-                "type": "object",
-                "properties": {
-                    "avg_cost_usd": {
-                        "type": "number"
-                    },
-                    "avg_time_seconds": {
-                        "type": "number"
-                    },
-                    "avg_tokens": {
-                        "type": "number"
-                    },
-                    "count": {
-                        "type": "integer"
-                    },
-                    "error_count": {
-                        "type": "integer"
-                    },
-                    "success_count": {
-                        "type": "integer"
-                    },
-                    "total_cost_usd": {
-                        "type": "number"
-                    },
-                    "total_time_seconds": {
-                        "type": "number"
-                    },
-                    "total_tokens": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.OcrResult": {
-                "type": "object",
-                "properties": {
-                    "confidence": {
-                        "type": "number"
-                    },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "text": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.PageStatus": {
-                "type": "object",
-                "properties": {
-                    "extract_complete": {
-                        "type": "boolean"
-                    },
-                    "ocr_complete": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "internal_server_endpoints.PageSummary": {
-                "type": "object",
-                "properties": {
-                    "ocr_complete": {
-                        "type": "boolean"
-                    },
-                    "page_num": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.PatternAnalysisResult": {
-                "type": "object",
-                "properties": {
-                    "excluded_ranges": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ExcludedRange"
-                        }
-                    },
-                    "patterns": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.DiscoveredPattern"
-                        }
-                    },
-                    "reasoning": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.PromptResponse": {
-                "type": "object",
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "doc_id": {
-                        "type": "string"
-                    },
-                    "hash": {
-                        "type": "string"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "text": {
-                        "type": "string"
-                    },
-                    "variables": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.PromptsListResponse": {
-                "type": "object",
-                "properties": {
-                    "prompts": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.PromptResponse"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.ProviderProgress": {
-                "type": "object",
-                "properties": {
-                    "complete": {
-                        "type": "integer"
-                    },
-                    "cost_usd": {
-                        "type": "number"
-                    },
-                    "total": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.ProvidersStatus": {
-                "type": "object",
-                "properties": {
-                    "llm": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "ocr": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.RerunTocResponse": {
-                "type": "object",
-                "properties": {
-                    "job_id": {
-                        "type": "string"
-                    },
-                    "message": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.SetPromptRequest": {
-                "type": "object",
-                "properties": {
-                    "note": {
-                        "type": "string"
-                    },
-                    "text": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.SettingResponse": {
-                "type": "object",
-                "properties": {
-                    "entry": {
-                        "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_config.Entry"
-                    },
-                    "error": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.SettingsResponse": {
-                "type": "object",
-                "properties": {
-                    "settings": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/github_com_jackzampolin_shelf_internal_config.Entry"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.StageProgress": {
-                "type": "object",
-                "properties": {
-                    "ocr": {
-                        "type": "object",
-                        "properties": {
-                            "complete": {
-                                "type": "integer"
-                            },
-                            "cost_by_provider": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "number",
-                                    "format": "float64"
-                                }
-                            },
-                            "total": {
-                                "type": "integer"
-                            },
-                            "total_cost_usd": {
-                                "type": "number"
-                            }
-                        }
-                    },
-                    "pattern_analysis": {
-                        "type": "object",
-                        "properties": {
-                            "complete": {
-                                "type": "boolean"
-                            },
-                            "cost_usd": {
-                                "type": "number"
-                            }
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.StartJobRequest": {
-                "type": "object",
-                "properties": {
-                    "force": {
-                        "description": "Optional: force restart even if already complete",
-                        "type": "boolean"
-                    },
-                    "job_type": {
-                        "description": "Optional: defaults to \"process-book\"",
-                        "type": "string"
-                    },
-                    "reset_from": {
-                        "description": "Optional: reset this operation and downstream deps before starting",
-                        "type": "string"
-                    },
-                    "variant": {
-                        "description": "Optional: pipeline variant (standard, photo-book, text-only, ocr-only)",
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.StartJobResponse": {
-                "type": "object",
-                "properties": {
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "job_id": {
-                        "type": "string"
-                    },
-                    "job_type": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.StatusResponse": {
-                "type": "object",
-                "properties": {
-                    "defra": {
-                        "$ref": "#/components/schemas/internal_server_endpoints.DefraStatus"
-                    },
-                    "providers": {
-                        "$ref": "#/components/schemas/internal_server_endpoints.ProvidersStatus"
-                    },
-                    "server": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.StorytellerExportResponse": {
-                "type": "object",
-                "properties": {
-                    "audio_chapters": {
-                        "type": "integer"
-                    },
-                    "author": {
-                        "type": "string"
-                    },
-                    "book_id": {
-                        "type": "string"
-                    },
-                    "chapter_count": {
-                        "type": "integer"
-                    },
-                    "created_at": {
-                        "type": "string"
-                    },
-                    "download_url": {
-                        "type": "string"
-                    },
-                    "file_path": {
-                        "type": "string"
-                    },
-                    "file_size": {
-                        "type": "integer"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "total_duration_ms": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.StructureStatus": {
-                "type": "object",
-                "properties": {
-                    "chapter_count": {
-                        "type": "integer"
-                    },
-                    "chapters_extracted": {
-                        "type": "integer"
-                    },
-                    "chapters_polished": {
-                        "type": "integer"
-                    },
-                    "chapters_total": {
-                        "type": "integer"
-                    },
-                    "complete": {
-                        "type": "boolean"
-                    },
-                    "cost_usd": {
-                        "type": "number"
-                    },
-                    "failed": {
-                        "type": "boolean"
-                    },
-                    "phase": {
-                        "description": "Phase tracking (build -> extract -> classify -> polish -> finalize)",
-                        "type": "string"
-                    },
-                    "polish_failed": {
-                        "type": "integer"
-                    },
-                    "retries": {
-                        "type": "integer"
-                    },
-                    "started": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            "internal_server_endpoints.SyncVoicesResponse": {
-                "type": "object",
-                "properties": {
-                    "message": {
-                        "type": "string"
-                    },
-                    "synced": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "internal_server_endpoints.TTSConfigResponse": {
-                "type": "object",
-                "properties": {
-                    "default_format": {
-                        "type": "string"
-                    },
-                    "default_voice": {
-                        "type": "string"
-                    },
-                    "formats": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "model": {
-                        "type": "string"
-                    },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "voice_cloning_url": {
-                        "type": "string"
-                    },
-                    "voices": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.TTSVoice"
-                        }
-                    }
-                }
-            },
-            "internal_server_endpoints.TTSVoice": {
-                "type": "object",
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "voice_id": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.ToCEntry": {
-                "type": "object",
-                "properties": {
-                    "actual_page_num": {
-                        "type": "integer"
-                    },
-                    "entry_number": {
-                        "type": "string"
-                    },
-                    "is_linked": {
-                        "type": "boolean"
-                    },
-                    "level": {
-                        "type": "integer"
-                    },
-                    "level_name": {
-                        "type": "string"
-                    },
-                    "printed_page_number": {
-                        "type": "string"
-                    },
-                    "sort_order": {
-                        "type": "integer"
-                    },
-                    "source": {
-                        "description": "\"extracted\" or \"discovered\"",
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.ToCStatus": {
-                "type": "object",
-                "properties": {
-                    "cost_usd": {
-                        "type": "number"
-                    },
-                    "discover_complete": {
-                        "description": "All entries discovered",
-                        "type": "boolean"
-                    },
-                    "end_page": {
-                        "type": "integer"
-                    },
-                    "entries": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/internal_server_endpoints.ToCEntry"
-                        }
-                    },
-                    "entries_discovered": {
-                        "description": "Actually discovered (source=\"discovered\")",
-                        "type": "integer"
-                    },
-                    "entries_linked": {
-                        "type": "integer"
-                    },
-                    "entries_to_find": {
-                        "description": "From pattern analysis (how many should be discovered)",
-                        "type": "integer"
-                    },
-                    "entry_count": {
-                        "description": "Entries (when extracted)",
-                        "type": "integer"
-                    },
-                    "excluded_ranges": {
-                        "description": "Number of excluded page ranges",
-                        "type": "integer"
-                    },
-                    "extract_complete": {
-                        "type": "boolean"
-                    },
-                    "extract_failed": {
-                        "type": "boolean"
-                    },
-                    "extract_started": {
-                        "description": "Extract stage",
-                        "type": "boolean"
-                    },
-                    "finalize_complete": {
-                        "type": "boolean"
-                    },
-                    "finalize_failed": {
-                        "type": "boolean"
-                    },
-                    "finalize_retries": {
-                        "type": "integer"
-                    },
-                    "finalize_started": {
-                        "description": "Finalize stage (overall)",
-                        "type": "boolean"
-                    },
-                    "finder_complete": {
-                        "type": "boolean"
-                    },
-                    "finder_failed": {
-                        "type": "boolean"
-                    },
-                    "finder_started": {
-                        "description": "Finder stage",
-                        "type": "boolean"
-                    },
-                    "found": {
-                        "type": "boolean"
-                    },
-                    "link_complete": {
-                        "type": "boolean"
-                    },
-                    "link_failed": {
-                        "type": "boolean"
-                    },
-                    "link_retries": {
-                        "type": "integer"
-                    },
-                    "link_started": {
-                        "description": "Link stage",
-                        "type": "boolean"
-                    },
-                    "pattern_analysis": {
-                        "description": "Full pattern analysis result",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/internal_server_endpoints.PatternAnalysisResult"
-                            }
-                        ]
-                    },
-                    "pattern_complete": {
-                        "description": "Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation",
-                        "type": "boolean"
-                    },
-                    "patterns_found": {
-                        "description": "Number of patterns discovered",
-                        "type": "integer"
-                    },
-                    "start_page": {
-                        "type": "integer"
-                    },
-                    "validate_complete": {
-                        "description": "Gap validation done (same as FinalizeComplete for now)",
-                        "type": "boolean"
-                    }
-                }
-            },
-            "internal_server_endpoints.UpdateJobRequest": {
-                "type": "object",
-                "properties": {
-                    "error": {
-                        "type": "string"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "additionalProperties": {}
-                    },
-                    "status": {
-                        "type": "string"
-                    }
-                }
-            },
-            "internal_server_endpoints.UpdateSettingRequest": {
-                "type": "object",
-                "properties": {
-                    "description": {
-                        "type": "string"
-                    },
-                    "value": {}
-                }
-            },
-            "internal_server_endpoints.VoiceResponse": {
-                "type": "object",
-                "properties": {
-                    "created_at": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "is_default": {
-                        "type": "boolean"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "synced_at": {
-                        "type": "string"
-                    },
-                    "voice_id": {
-                        "type": "string"
                     }
                 }
             },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -39,31 +39,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.AgentLogDetailResponse"
+                            "$ref": "#/definitions/endpoints.AgentLogDetailResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -83,19 +83,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListBooksResponse"
+                            "$ref": "#/definitions/endpoints.ListBooksResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -121,7 +121,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.IngestRequest"
+                            "$ref": "#/definitions/endpoints.IngestRequest"
                         }
                     }
                 ],
@@ -129,25 +129,25 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.IngestResponse"
+                            "$ref": "#/definitions/endpoints.IngestResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -197,25 +197,25 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.IngestResponse"
+                            "$ref": "#/definitions/endpoints.IngestResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -262,25 +262,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.AgentLogsListResponse"
+                            "$ref": "#/definitions/endpoints.AgentLogsListResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -310,25 +310,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.AudioStatusResponse"
+                            "$ref": "#/definitions/endpoints.AudioStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -371,13 +371,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -407,25 +407,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.EpubExportResponse"
+                            "$ref": "#/definitions/endpoints.EpubExportResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -461,13 +461,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -498,25 +498,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StorytellerExportResponse"
+                            "$ref": "#/definitions/endpoints.StorytellerExportResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -553,13 +553,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -592,7 +592,7 @@
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GenerateAudioRequest"
+                            "$ref": "#/definitions/endpoints.GenerateAudioRequest"
                         }
                     }
                 ],
@@ -600,31 +600,31 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GenerateAudioResponse"
+                            "$ref": "#/definitions/endpoints.GenerateAudioResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -653,25 +653,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListPagesResponse"
+                            "$ref": "#/definitions/endpoints.ListPagesResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -707,31 +707,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GetPageResponse"
+                            "$ref": "#/definitions/endpoints.GetPageResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -773,19 +773,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -814,37 +814,37 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.RerunTocResponse"
+                            "$ref": "#/definitions/endpoints.RerunTocResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "412": {
                         "description": "Not enough pages have OCR complete",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -873,31 +873,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.Book"
+                            "$ref": "#/definitions/endpoints.Book"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -938,25 +938,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ChaptersResponse"
+                            "$ref": "#/definitions/endpoints.ChaptersResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -991,25 +991,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsCostResponse"
+                            "$ref": "#/definitions/endpoints.MetricsCostResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1039,25 +1039,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsDetailedResponse"
+                            "$ref": "#/definitions/endpoints.MetricsDetailedResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1086,13 +1086,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptsListResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptsListResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1128,19 +1128,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1178,7 +1178,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SetPromptRequest"
+                            "$ref": "#/definitions/endpoints.SetPromptRequest"
                         }
                     }
                 ],
@@ -1186,19 +1186,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1232,19 +1232,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
+                            "$ref": "#/definitions/endpoints.BookPromptResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1264,7 +1264,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.HealthResponse"
+                            "$ref": "#/definitions/endpoints.HealthResponse"
                         }
                     }
                 }
@@ -1304,19 +1304,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListJobsResponse"
+                            "$ref": "#/definitions/endpoints.ListJobsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1340,7 +1340,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.CreateJobRequest"
+                            "$ref": "#/definitions/endpoints.CreateJobRequest"
                         }
                     }
                 ],
@@ -1348,25 +1348,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.CreateJobResponse"
+                            "$ref": "#/definitions/endpoints.CreateJobResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1398,7 +1398,7 @@
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StartJobRequest"
+                            "$ref": "#/definitions/endpoints.StartJobRequest"
                         }
                     }
                 ],
@@ -1406,25 +1406,25 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StartJobResponse"
+                            "$ref": "#/definitions/endpoints.StartJobResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1459,25 +1459,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.JobStatusResponse"
+                            "$ref": "#/definitions/endpoints.JobStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1506,25 +1506,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.DetailedJobStatusResponse"
+                            "$ref": "#/definitions/endpoints.DetailedJobStatusResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1553,31 +1553,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.GetJobResponse"
+                            "$ref": "#/definitions/endpoints.GetJobResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1604,25 +1604,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1653,7 +1653,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.UpdateJobRequest"
+                            "$ref": "#/definitions/endpoints.UpdateJobRequest"
                         }
                     }
                 ],
@@ -1667,19 +1667,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1767,19 +1767,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.LLMCallsResponse"
+                            "$ref": "#/definitions/endpoints.LLMCallsResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1808,13 +1808,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.LLMCallCountsResponse"
+                            "$ref": "#/definitions/endpoints.LLMCallCountsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1843,19 +1843,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.LLMCallResponse"
+                            "$ref": "#/definitions/endpoints.LLMCallResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1913,19 +1913,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListMetricsResponse"
+                            "$ref": "#/definitions/endpoints.ListMetricsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -1983,19 +1983,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsCostResponse"
+                            "$ref": "#/definitions/endpoints.MetricsCostResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2023,19 +2023,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsDetailedResponse"
+                            "$ref": "#/definitions/endpoints.MetricsDetailedResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2087,19 +2087,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.MetricsSummaryResponse"
+                            "$ref": "#/definitions/endpoints.MetricsSummaryResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2119,13 +2119,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.PromptsListResponse"
+                            "$ref": "#/definitions/endpoints.PromptsListResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2154,19 +2154,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.PromptResponse"
+                            "$ref": "#/definitions/endpoints.PromptResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2186,13 +2186,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.HealthResponse"
+                            "$ref": "#/definitions/endpoints.HealthResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.HealthResponse"
+                            "$ref": "#/definitions/endpoints.HealthResponse"
                         }
                     }
                 }
@@ -2212,13 +2212,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingsResponse"
+                            "$ref": "#/definitions/endpoints.SettingsResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2247,25 +2247,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingResponse"
+                            "$ref": "#/definitions/endpoints.SettingResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2294,19 +2294,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingResponse"
+                            "$ref": "#/definitions/endpoints.SettingResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2337,7 +2337,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.UpdateSettingRequest"
+                            "$ref": "#/definitions/endpoints.UpdateSettingRequest"
                         }
                     }
                 ],
@@ -2345,19 +2345,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SettingResponse"
+                            "$ref": "#/definitions/endpoints.SettingResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2377,7 +2377,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.StatusResponse"
+                            "$ref": "#/definitions/endpoints.StatusResponse"
                         }
                     }
                 }
@@ -2397,19 +2397,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.TTSConfigResponse"
+                            "$ref": "#/definitions/endpoints.TTSConfigResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2429,13 +2429,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ListVoicesResponse"
+                            "$ref": "#/definitions/endpoints.ListVoicesResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2459,7 +2459,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.CreateVoiceRequest"
+                            "$ref": "#/definitions/endpoints.CreateVoiceRequest"
                         }
                     }
                 ],
@@ -2467,19 +2467,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.VoiceResponse"
+                            "$ref": "#/definitions/endpoints.VoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2499,13 +2499,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.SyncVoicesResponse"
+                            "$ref": "#/definitions/endpoints.SyncVoicesResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2543,13 +2543,13 @@
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2587,19 +2587,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/internal_server_endpoints.ErrorResponse"
+                            "$ref": "#/definitions/endpoints.ErrorResponse"
                         }
                     }
                 }
@@ -2607,6 +2607,1559 @@
         }
     },
     "definitions": {
+        "endpoints.AgentLogDetailResponse": {
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "iterations": {
+                    "type": "integer"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "messages": {
+                    "description": "Detailed data",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "result": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "tool_calls": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "endpoints.AgentLogSummary": {
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "iterations": {
+                    "type": "integer"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.AgentLogSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "agent_type": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "iterations": {
+                    "type": "integer"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.AgentLogsListResponse": {
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.AgentLogSummaryResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.AudioStatusResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "chapters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterAudioStatus"
+                    }
+                },
+                "format": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "segment_count": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "total_cost_usd": {
+                    "type": "number"
+                },
+                "total_duration_ms": {
+                    "type": "integer"
+                },
+                "voice": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.Book": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "page_count": {
+                    "type": "integer"
+                },
+                "page_pattern_analysis_json": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.BookMetadata": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "authors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string"
+                },
+                "isbn": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "lccn": {
+                    "type": "string"
+                },
+                "publication_year": {
+                    "type": "integer"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "subjects": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.BookPromptResponse": {
+            "type": "object",
+            "properties": {
+                "cid": {
+                    "type": "string"
+                },
+                "is_override": {
+                    "type": "boolean"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "endpoints.BookPromptsListResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.BookPromptResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.ChapterAudioStatus": {
+            "type": "object",
+            "properties": {
+                "audio_file": {
+                    "type": "string"
+                },
+                "chapter_idx": {
+                    "type": "integer"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "download_url": {
+                    "type": "string"
+                },
+                "duration_ms": {
+                    "type": "integer"
+                },
+                "segment_count": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ChapterPage": {
+            "type": "object",
+            "properties": {
+                "ocr_markdown": {
+                    "type": "string"
+                },
+                "page_num": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ChapterParagraph": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "polished_text": {
+                    "type": "string"
+                },
+                "raw_text": {
+                    "type": "string"
+                },
+                "sort_order": {
+                    "type": "integer"
+                },
+                "start_page": {
+                    "type": "integer"
+                },
+                "word_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ChapterWithText": {
+            "type": "object",
+            "properties": {
+                "audio_include": {
+                    "type": "boolean"
+                },
+                "audio_include_reasoning": {
+                    "type": "string"
+                },
+                "classification_reasoning": {
+                    "type": "string"
+                },
+                "content_type": {
+                    "type": "string"
+                },
+                "edits_applied_json": {
+                    "type": "string"
+                },
+                "end_page": {
+                    "type": "integer"
+                },
+                "entry_id": {
+                    "type": "string"
+                },
+                "entry_number": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "level_name": {
+                    "type": "string"
+                },
+                "matter_type": {
+                    "type": "string"
+                },
+                "page_count": {
+                    "type": "integer"
+                },
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterPage"
+                    }
+                },
+                "paragraphs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterParagraph"
+                    }
+                },
+                "polish_complete": {
+                    "type": "boolean"
+                },
+                "polish_failed": {
+                    "type": "boolean"
+                },
+                "polished_text": {
+                    "type": "string"
+                },
+                "sort_order": {
+                    "type": "integer"
+                },
+                "start_page": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "word_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ChaptersResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "book_title": {
+                    "type": "string"
+                },
+                "chapters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ChapterWithText"
+                    }
+                },
+                "has_chapters": {
+                    "type": "boolean"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.CreateJobRequest": {
+            "type": "object",
+            "properties": {
+                "job_type": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "endpoints.CreateJobResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.CreateVoiceRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "voice_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.DefraStatus": {
+            "type": "object",
+            "properties": {
+                "container": {
+                    "type": "string"
+                },
+                "health": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.DetailedJobStatusResponse": {
+            "type": "object",
+            "properties": {
+                "agent_logs": {
+                    "description": "Agent logs summary",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.AgentLogSummary"
+                    }
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Metadata status",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.MetadataStatus"
+                        }
+                    ]
+                },
+                "ocr_progress": {
+                    "description": "Per-provider OCR progress",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/endpoints.ProviderProgress"
+                    }
+                },
+                "stages": {
+                    "description": "Stage progress with costs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.StageProgress"
+                        }
+                    ]
+                },
+                "structure": {
+                    "description": "Structure status (common-structure job)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.StructureStatus"
+                        }
+                    ]
+                },
+                "toc": {
+                    "description": "ToC status",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.ToCStatus"
+                        }
+                    ]
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.DiscoveredPattern": {
+            "type": "object",
+            "properties": {
+                "heading_format": {
+                    "type": "string"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "level_name": {
+                    "type": "string"
+                },
+                "pattern_type": {
+                    "type": "string"
+                },
+                "range_end": {
+                    "type": "string"
+                },
+                "range_start": {
+                    "type": "string"
+                },
+                "reasoning": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.EpubExportResponse": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "download_url": {
+                    "type": "string"
+                },
+                "file_path": {
+                    "type": "string"
+                },
+                "file_size": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ExcludedRange": {
+            "type": "object",
+            "properties": {
+                "end_page": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "start_page": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.GenerateAudioRequest": {
+            "type": "object",
+            "properties": {
+                "format": {
+                    "description": "Optional: output format (mp3, wav)",
+                    "type": "string"
+                },
+                "voice": {
+                    "description": "Optional: voice ID",
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.GenerateAudioResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "chapters": {
+                    "type": "integer"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.GetJobResponse": {
+            "type": "object",
+            "properties": {
+                "_docID": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "completed_at": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "job_type": {
+                    "type": "string"
+                },
+                "live_status": {
+                    "description": "Live status fields (only populated for running jobs)",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "pending_units": {
+                    "type": "integer"
+                },
+                "progress": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"
+                    }
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Status"
+                },
+                "worker_status": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"
+                    }
+                }
+            }
+        },
+        "endpoints.GetPageResponse": {
+            "type": "object",
+            "properties": {
+                "ocr_markdown": {
+                    "type": "string"
+                },
+                "ocr_results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.OcrResult"
+                    }
+                },
+                "page_num": {
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/definitions/endpoints.PageStatus"
+                }
+            }
+        },
+        "endpoints.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "defra": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.IngestRequest": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "pdf_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.IngestResponse": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "process_job_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.JobStatusResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "is_complete": {
+                    "type": "boolean"
+                },
+                "job_type": {
+                    "type": "string"
+                },
+                "metadata_complete": {
+                    "type": "boolean"
+                },
+                "ocr_complete": {
+                    "type": "integer"
+                },
+                "toc_extracted": {
+                    "type": "boolean"
+                },
+                "toc_found": {
+                    "type": "boolean"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.LLMCallCountsResponse": {
+            "type": "object",
+            "properties": {
+                "counts": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "endpoints.LLMCallResponse": {
+            "type": "object",
+            "properties": {
+                "call": {
+                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
+                },
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.LLMCallsResponse": {
+            "type": "object",
+            "properties": {
+                "calls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ListBooksResponse": {
+            "type": "object",
+            "properties": {
+                "books": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.Book"
+                    }
+                }
+            }
+        },
+        "endpoints.ListJobsResponse": {
+            "type": "object",
+            "properties": {
+                "jobs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Record"
+                    }
+                }
+            }
+        },
+        "endpoints.ListMetricsResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "metrics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.Metric"
+                    }
+                }
+            }
+        },
+        "endpoints.ListPagesResponse": {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.PageSummary"
+                    }
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ListVoicesResponse": {
+            "type": "object",
+            "properties": {
+                "voices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.VoiceResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.MetadataStatus": {
+            "type": "object",
+            "properties": {
+                "complete": {
+                    "type": "boolean"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "data": {
+                    "$ref": "#/definitions/endpoints.BookMetadata"
+                },
+                "failed": {
+                    "type": "boolean"
+                },
+                "started": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.MetricsCostResponse": {
+            "type": "object",
+            "properties": {
+                "breakdown": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "number",
+                        "format": "float64"
+                    }
+                },
+                "total_cost_usd": {
+                    "type": "number"
+                }
+            }
+        },
+        "endpoints.MetricsDetailedResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "stages": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.DetailedStats"
+                    }
+                }
+            }
+        },
+        "endpoints.MetricsSummaryResponse": {
+            "type": "object",
+            "properties": {
+                "avg_cost_usd": {
+                    "type": "number"
+                },
+                "avg_time_seconds": {
+                    "type": "number"
+                },
+                "avg_tokens": {
+                    "type": "number"
+                },
+                "count": {
+                    "type": "integer"
+                },
+                "error_count": {
+                    "type": "integer"
+                },
+                "success_count": {
+                    "type": "integer"
+                },
+                "total_cost_usd": {
+                    "type": "number"
+                },
+                "total_time_seconds": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.OcrResult": {
+            "type": "object",
+            "properties": {
+                "confidence": {
+                    "type": "number"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.PageStatus": {
+            "type": "object",
+            "properties": {
+                "extract_complete": {
+                    "type": "boolean"
+                },
+                "ocr_complete": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.PageSummary": {
+            "type": "object",
+            "properties": {
+                "ocr_complete": {
+                    "type": "boolean"
+                },
+                "page_num": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.PatternAnalysisResult": {
+            "type": "object",
+            "properties": {
+                "excluded_ranges": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ExcludedRange"
+                    }
+                },
+                "patterns": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.DiscoveredPattern"
+                    }
+                },
+                "reasoning": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.PromptResponse": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "doc_id": {
+                    "type": "string"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "endpoints.PromptsListResponse": {
+            "type": "object",
+            "properties": {
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.PromptResponse"
+                    }
+                }
+            }
+        },
+        "endpoints.ProviderProgress": {
+            "type": "object",
+            "properties": {
+                "complete": {
+                    "type": "integer"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.ProvidersStatus": {
+            "type": "object",
+            "properties": {
+                "llm": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "ocr": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "endpoints.RerunTocResponse": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.SetPromptRequest": {
+            "type": "object",
+            "properties": {
+                "note": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.SettingResponse": {
+            "type": "object",
+            "properties": {
+                "entry": {
+                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
+                },
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.SettingsResponse": {
+            "type": "object",
+            "properties": {
+                "settings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
+                    }
+                }
+            }
+        },
+        "endpoints.StageProgress": {
+            "type": "object",
+            "properties": {
+                "ocr": {
+                    "type": "object",
+                    "properties": {
+                        "complete": {
+                            "type": "integer"
+                        },
+                        "cost_by_provider": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "number",
+                                "format": "float64"
+                            }
+                        },
+                        "total": {
+                            "type": "integer"
+                        },
+                        "total_cost_usd": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "pattern_analysis": {
+                    "type": "object",
+                    "properties": {
+                        "complete": {
+                            "type": "boolean"
+                        },
+                        "cost_usd": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        },
+        "endpoints.StartJobRequest": {
+            "type": "object",
+            "properties": {
+                "force": {
+                    "description": "Optional: force restart even if already complete",
+                    "type": "boolean"
+                },
+                "job_type": {
+                    "description": "Optional: defaults to \"process-book\"",
+                    "type": "string"
+                },
+                "reset_from": {
+                    "description": "Optional: reset this operation and downstream deps before starting",
+                    "type": "string"
+                },
+                "variant": {
+                    "description": "Optional: pipeline variant (standard, photo-book, text-only, ocr-only)",
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.StartJobResponse": {
+            "type": "object",
+            "properties": {
+                "book_id": {
+                    "type": "string"
+                },
+                "job_id": {
+                    "type": "string"
+                },
+                "job_type": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.StatusResponse": {
+            "type": "object",
+            "properties": {
+                "defra": {
+                    "$ref": "#/definitions/endpoints.DefraStatus"
+                },
+                "providers": {
+                    "$ref": "#/definitions/endpoints.ProvidersStatus"
+                },
+                "server": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.StorytellerExportResponse": {
+            "type": "object",
+            "properties": {
+                "audio_chapters": {
+                    "type": "integer"
+                },
+                "author": {
+                    "type": "string"
+                },
+                "book_id": {
+                    "type": "string"
+                },
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "download_url": {
+                    "type": "string"
+                },
+                "file_path": {
+                    "type": "string"
+                },
+                "file_size": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "total_duration_ms": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.StructureStatus": {
+            "type": "object",
+            "properties": {
+                "chapter_count": {
+                    "type": "integer"
+                },
+                "chapters_extracted": {
+                    "type": "integer"
+                },
+                "chapters_polished": {
+                    "type": "integer"
+                },
+                "chapters_total": {
+                    "type": "integer"
+                },
+                "complete": {
+                    "type": "boolean"
+                },
+                "cost_usd": {
+                    "type": "number"
+                },
+                "failed": {
+                    "type": "boolean"
+                },
+                "phase": {
+                    "description": "Phase tracking (build -\u003e extract -\u003e classify -\u003e polish -\u003e finalize)",
+                    "type": "string"
+                },
+                "polish_failed": {
+                    "type": "integer"
+                },
+                "retries": {
+                    "type": "integer"
+                },
+                "started": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.SyncVoicesResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "synced": {
+                    "type": "integer"
+                }
+            }
+        },
+        "endpoints.TTSConfigResponse": {
+            "type": "object",
+            "properties": {
+                "default_format": {
+                    "type": "string"
+                },
+                "default_voice": {
+                    "type": "string"
+                },
+                "formats": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "voice_cloning_url": {
+                    "type": "string"
+                },
+                "voices": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.TTSVoice"
+                    }
+                }
+            }
+        },
+        "endpoints.TTSVoice": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "voice_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ToCEntry": {
+            "type": "object",
+            "properties": {
+                "actual_page_num": {
+                    "type": "integer"
+                },
+                "entry_number": {
+                    "type": "string"
+                },
+                "is_linked": {
+                    "type": "boolean"
+                },
+                "level": {
+                    "type": "integer"
+                },
+                "level_name": {
+                    "type": "string"
+                },
+                "printed_page_number": {
+                    "type": "string"
+                },
+                "sort_order": {
+                    "type": "integer"
+                },
+                "source": {
+                    "description": "\"extracted\" or \"discovered\"",
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.ToCStatus": {
+            "type": "object",
+            "properties": {
+                "cost_usd": {
+                    "type": "number"
+                },
+                "discover_complete": {
+                    "description": "All entries discovered",
+                    "type": "boolean"
+                },
+                "end_page": {
+                    "type": "integer"
+                },
+                "entries": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/endpoints.ToCEntry"
+                    }
+                },
+                "entries_discovered": {
+                    "description": "Actually discovered (source=\"discovered\")",
+                    "type": "integer"
+                },
+                "entries_linked": {
+                    "type": "integer"
+                },
+                "entries_to_find": {
+                    "description": "From pattern analysis (how many should be discovered)",
+                    "type": "integer"
+                },
+                "entry_count": {
+                    "description": "Entries (when extracted)",
+                    "type": "integer"
+                },
+                "excluded_ranges": {
+                    "description": "Number of excluded page ranges",
+                    "type": "integer"
+                },
+                "extract_complete": {
+                    "type": "boolean"
+                },
+                "extract_failed": {
+                    "type": "boolean"
+                },
+                "extract_started": {
+                    "description": "Extract stage",
+                    "type": "boolean"
+                },
+                "finalize_complete": {
+                    "type": "boolean"
+                },
+                "finalize_failed": {
+                    "type": "boolean"
+                },
+                "finalize_retries": {
+                    "type": "integer"
+                },
+                "finalize_started": {
+                    "description": "Finalize stage (overall)",
+                    "type": "boolean"
+                },
+                "finder_complete": {
+                    "type": "boolean"
+                },
+                "finder_failed": {
+                    "type": "boolean"
+                },
+                "finder_started": {
+                    "description": "Finder stage",
+                    "type": "boolean"
+                },
+                "found": {
+                    "type": "boolean"
+                },
+                "link_complete": {
+                    "type": "boolean"
+                },
+                "link_failed": {
+                    "type": "boolean"
+                },
+                "link_retries": {
+                    "type": "integer"
+                },
+                "link_started": {
+                    "description": "Link stage",
+                    "type": "boolean"
+                },
+                "pattern_analysis": {
+                    "description": "Full pattern analysis result",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/endpoints.PatternAnalysisResult"
+                        }
+                    ]
+                },
+                "pattern_complete": {
+                    "description": "Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation",
+                    "type": "boolean"
+                },
+                "patterns_found": {
+                    "description": "Number of patterns discovered",
+                    "type": "integer"
+                },
+                "start_page": {
+                    "type": "integer"
+                },
+                "validate_complete": {
+                    "description": "Gap validation done (same as FinalizeComplete for now)",
+                    "type": "boolean"
+                }
+            }
+        },
+        "endpoints.UpdateJobRequest": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "endpoints.UpdateSettingRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "value": {}
+            }
+        },
+        "endpoints.VoiceResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "synced_at": {
+                    "type": "string"
+                },
+                "voice_id": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_jackzampolin_shelf_internal_config.Entry": {
             "type": "object",
             "properties": {
@@ -2948,1550 +4501,6 @@
                 },
                 "total_tokens": {
                     "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogDetailResponse": {
-            "type": "object",
-            "properties": {
-                "agent_type": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iterations": {
-                    "type": "integer"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "messages": {
-                    "description": "Detailed data",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "result": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                },
-                "tool_calls": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogSummary": {
-            "type": "object",
-            "properties": {
-                "agent_type": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iterations": {
-                    "type": "integer"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "agent_type": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "iterations": {
-                    "type": "integer"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.AgentLogsListResponse": {
-            "type": "object",
-            "properties": {
-                "logs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.AgentLogSummaryResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.AudioStatusResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "chapters": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterAudioStatus"
-                    }
-                },
-                "format": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "segment_count": {
-                    "type": "integer"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "total_cost_usd": {
-                    "type": "number"
-                },
-                "total_duration_ms": {
-                    "type": "integer"
-                },
-                "voice": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.Book": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "page_count": {
-                    "type": "integer"
-                },
-                "page_pattern_analysis_json": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.BookMetadata": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "authors": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "description": {
-                    "type": "string"
-                },
-                "isbn": {
-                    "type": "string"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "lccn": {
-                    "type": "string"
-                },
-                "publication_year": {
-                    "type": "integer"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "subjects": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.BookPromptResponse": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": "string"
-                },
-                "is_override": {
-                    "type": "boolean"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "variables": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.BookPromptsListResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "prompts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.BookPromptResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterAudioStatus": {
-            "type": "object",
-            "properties": {
-                "audio_file": {
-                    "type": "string"
-                },
-                "chapter_idx": {
-                    "type": "integer"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "download_url": {
-                    "type": "string"
-                },
-                "duration_ms": {
-                    "type": "integer"
-                },
-                "segment_count": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterPage": {
-            "type": "object",
-            "properties": {
-                "ocr_markdown": {
-                    "type": "string"
-                },
-                "page_num": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterParagraph": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "polished_text": {
-                    "type": "string"
-                },
-                "raw_text": {
-                    "type": "string"
-                },
-                "sort_order": {
-                    "type": "integer"
-                },
-                "start_page": {
-                    "type": "integer"
-                },
-                "word_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ChapterWithText": {
-            "type": "object",
-            "properties": {
-                "classification_reasoning": {
-                    "type": "string"
-                },
-                "edits_applied_json": {
-                    "type": "string"
-                },
-                "end_page": {
-                    "type": "integer"
-                },
-                "entry_id": {
-                    "type": "string"
-                },
-                "entry_number": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "level": {
-                    "type": "integer"
-                },
-                "level_name": {
-                    "type": "string"
-                },
-                "matter_type": {
-                    "type": "string"
-                },
-                "page_count": {
-                    "type": "integer"
-                },
-                "pages": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterPage"
-                    }
-                },
-                "paragraphs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterParagraph"
-                    }
-                },
-                "polish_complete": {
-                    "type": "boolean"
-                },
-                "polish_failed": {
-                    "type": "boolean"
-                },
-                "polished_text": {
-                    "type": "string"
-                },
-                "sort_order": {
-                    "type": "integer"
-                },
-                "start_page": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "word_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ChaptersResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "book_title": {
-                    "type": "string"
-                },
-                "chapters": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ChapterWithText"
-                    }
-                },
-                "has_chapters": {
-                    "type": "boolean"
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.CreateJobRequest": {
-            "type": "object",
-            "properties": {
-                "job_type": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                }
-            }
-        },
-        "internal_server_endpoints.CreateJobResponse": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.CreateVoiceRequest": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "voice_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.DefraStatus": {
-            "type": "object",
-            "properties": {
-                "container": {
-                    "type": "string"
-                },
-                "health": {
-                    "type": "string"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.DetailedJobStatusResponse": {
-            "type": "object",
-            "properties": {
-                "agent_logs": {
-                    "description": "Agent logs summary",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.AgentLogSummary"
-                    }
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "description": "Metadata status",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.MetadataStatus"
-                        }
-                    ]
-                },
-                "ocr_progress": {
-                    "description": "Per-provider OCR progress",
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/internal_server_endpoints.ProviderProgress"
-                    }
-                },
-                "stages": {
-                    "description": "Stage progress with costs",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.StageProgress"
-                        }
-                    ]
-                },
-                "structure": {
-                    "description": "Structure status (common-structure job)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.StructureStatus"
-                        }
-                    ]
-                },
-                "toc": {
-                    "description": "ToC status",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.ToCStatus"
-                        }
-                    ]
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.DiscoveredPattern": {
-            "type": "object",
-            "properties": {
-                "heading_format": {
-                    "type": "string"
-                },
-                "level": {
-                    "type": "integer"
-                },
-                "level_name": {
-                    "type": "string"
-                },
-                "pattern_type": {
-                    "type": "string"
-                },
-                "range_end": {
-                    "type": "string"
-                },
-                "range_start": {
-                    "type": "string"
-                },
-                "reasoning": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.EpubExportResponse": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "download_url": {
-                    "type": "string"
-                },
-                "file_path": {
-                    "type": "string"
-                },
-                "file_size": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ExcludedRange": {
-            "type": "object",
-            "properties": {
-                "end_page": {
-                    "type": "integer"
-                },
-                "reason": {
-                    "type": "string"
-                },
-                "start_page": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.GenerateAudioRequest": {
-            "type": "object",
-            "properties": {
-                "format": {
-                    "description": "Optional: output format (mp3, wav)",
-                    "type": "string"
-                },
-                "voice": {
-                    "description": "Optional: voice ID",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.GenerateAudioResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "chapters": {
-                    "type": "integer"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.GetJobResponse": {
-            "type": "object",
-            "properties": {
-                "_docID": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "completed_at": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "job_type": {
-                    "type": "string"
-                },
-                "live_status": {
-                    "description": "Live status fields (only populated for running jobs)",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "pending_units": {
-                    "type": "integer"
-                },
-                "progress": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"
-                    }
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Status"
-                },
-                "worker_status": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.GetPageResponse": {
-            "type": "object",
-            "properties": {
-                "ocr_markdown": {
-                    "type": "string"
-                },
-                "ocr_results": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.OcrResult"
-                    }
-                },
-                "page_num": {
-                    "type": "integer"
-                },
-                "status": {
-                    "$ref": "#/definitions/internal_server_endpoints.PageStatus"
-                }
-            }
-        },
-        "internal_server_endpoints.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "defra": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.IngestRequest": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "pdf_paths": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.IngestResponse": {
-            "type": "object",
-            "properties": {
-                "author": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "process_job_id": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.JobStatusResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "is_complete": {
-                    "type": "boolean"
-                },
-                "job_type": {
-                    "type": "string"
-                },
-                "metadata_complete": {
-                    "type": "boolean"
-                },
-                "ocr_complete": {
-                    "type": "integer"
-                },
-                "toc_extracted": {
-                    "type": "boolean"
-                },
-                "toc_found": {
-                    "type": "boolean"
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.LLMCallCountsResponse": {
-            "type": "object",
-            "properties": {
-                "counts": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "integer"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.LLMCallResponse": {
-            "type": "object",
-            "properties": {
-                "call": {
-                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
-                },
-                "error": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.LLMCallsResponse": {
-            "type": "object",
-            "properties": {
-                "calls": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call"
-                    }
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ListBooksResponse": {
-            "type": "object",
-            "properties": {
-                "books": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.Book"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ListJobsResponse": {
-            "type": "object",
-            "properties": {
-                "jobs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_jobs.Record"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ListMetricsResponse": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer"
-                },
-                "metrics": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.Metric"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ListPagesResponse": {
-            "type": "object",
-            "properties": {
-                "pages": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.PageSummary"
-                    }
-                },
-                "total_pages": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ListVoicesResponse": {
-            "type": "object",
-            "properties": {
-                "voices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.VoiceResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.MetadataStatus": {
-            "type": "object",
-            "properties": {
-                "complete": {
-                    "type": "boolean"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "data": {
-                    "$ref": "#/definitions/internal_server_endpoints.BookMetadata"
-                },
-                "failed": {
-                    "type": "boolean"
-                },
-                "started": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.MetricsCostResponse": {
-            "type": "object",
-            "properties": {
-                "breakdown": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "number",
-                        "format": "float64"
-                    }
-                },
-                "total_cost_usd": {
-                    "type": "number"
-                }
-            }
-        },
-        "internal_server_endpoints.MetricsDetailedResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "stages": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_metrics.DetailedStats"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.MetricsSummaryResponse": {
-            "type": "object",
-            "properties": {
-                "avg_cost_usd": {
-                    "type": "number"
-                },
-                "avg_time_seconds": {
-                    "type": "number"
-                },
-                "avg_tokens": {
-                    "type": "number"
-                },
-                "count": {
-                    "type": "integer"
-                },
-                "error_count": {
-                    "type": "integer"
-                },
-                "success_count": {
-                    "type": "integer"
-                },
-                "total_cost_usd": {
-                    "type": "number"
-                },
-                "total_time_seconds": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.OcrResult": {
-            "type": "object",
-            "properties": {
-                "confidence": {
-                    "type": "number"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.PageStatus": {
-            "type": "object",
-            "properties": {
-                "extract_complete": {
-                    "type": "boolean"
-                },
-                "ocr_complete": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.PageSummary": {
-            "type": "object",
-            "properties": {
-                "ocr_complete": {
-                    "type": "boolean"
-                },
-                "page_num": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.PatternAnalysisResult": {
-            "type": "object",
-            "properties": {
-                "excluded_ranges": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ExcludedRange"
-                    }
-                },
-                "patterns": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.DiscoveredPattern"
-                    }
-                },
-                "reasoning": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.PromptResponse": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "doc_id": {
-                    "type": "string"
-                },
-                "hash": {
-                    "type": "string"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                },
-                "variables": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.PromptsListResponse": {
-            "type": "object",
-            "properties": {
-                "prompts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.PromptResponse"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.ProviderProgress": {
-            "type": "object",
-            "properties": {
-                "complete": {
-                    "type": "integer"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "total": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.ProvidersStatus": {
-            "type": "object",
-            "properties": {
-                "llm": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "ocr": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.RerunTocResponse": {
-            "type": "object",
-            "properties": {
-                "job_id": {
-                    "type": "string"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.SetPromptRequest": {
-            "type": "object",
-            "properties": {
-                "note": {
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.SettingResponse": {
-            "type": "object",
-            "properties": {
-                "entry": {
-                    "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
-                },
-                "error": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.SettingsResponse": {
-            "type": "object",
-            "properties": {
-                "settings": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/github_com_jackzampolin_shelf_internal_config.Entry"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.StageProgress": {
-            "type": "object",
-            "properties": {
-                "ocr": {
-                    "type": "object",
-                    "properties": {
-                        "complete": {
-                            "type": "integer"
-                        },
-                        "cost_by_provider": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "number",
-                                "format": "float64"
-                            }
-                        },
-                        "total": {
-                            "type": "integer"
-                        },
-                        "total_cost_usd": {
-                            "type": "number"
-                        }
-                    }
-                },
-                "pattern_analysis": {
-                    "type": "object",
-                    "properties": {
-                        "complete": {
-                            "type": "boolean"
-                        },
-                        "cost_usd": {
-                            "type": "number"
-                        }
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.StartJobRequest": {
-            "type": "object",
-            "properties": {
-                "force": {
-                    "description": "Optional: force restart even if already complete",
-                    "type": "boolean"
-                },
-                "job_type": {
-                    "description": "Optional: defaults to \"process-book\"",
-                    "type": "string"
-                },
-                "reset_from": {
-                    "description": "Optional: reset this operation and downstream deps before starting",
-                    "type": "string"
-                },
-                "variant": {
-                    "description": "Optional: pipeline variant (standard, photo-book, text-only, ocr-only)",
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.StartJobResponse": {
-            "type": "object",
-            "properties": {
-                "book_id": {
-                    "type": "string"
-                },
-                "job_id": {
-                    "type": "string"
-                },
-                "job_type": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.StatusResponse": {
-            "type": "object",
-            "properties": {
-                "defra": {
-                    "$ref": "#/definitions/internal_server_endpoints.DefraStatus"
-                },
-                "providers": {
-                    "$ref": "#/definitions/internal_server_endpoints.ProvidersStatus"
-                },
-                "server": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.StorytellerExportResponse": {
-            "type": "object",
-            "properties": {
-                "audio_chapters": {
-                    "type": "integer"
-                },
-                "author": {
-                    "type": "string"
-                },
-                "book_id": {
-                    "type": "string"
-                },
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "download_url": {
-                    "type": "string"
-                },
-                "file_path": {
-                    "type": "string"
-                },
-                "file_size": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "total_duration_ms": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.StructureStatus": {
-            "type": "object",
-            "properties": {
-                "chapter_count": {
-                    "type": "integer"
-                },
-                "chapters_extracted": {
-                    "type": "integer"
-                },
-                "chapters_polished": {
-                    "type": "integer"
-                },
-                "chapters_total": {
-                    "type": "integer"
-                },
-                "complete": {
-                    "type": "boolean"
-                },
-                "cost_usd": {
-                    "type": "number"
-                },
-                "failed": {
-                    "type": "boolean"
-                },
-                "phase": {
-                    "description": "Phase tracking (build -\u003e extract -\u003e classify -\u003e polish -\u003e finalize)",
-                    "type": "string"
-                },
-                "polish_failed": {
-                    "type": "integer"
-                },
-                "retries": {
-                    "type": "integer"
-                },
-                "started": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.SyncVoicesResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string"
-                },
-                "synced": {
-                    "type": "integer"
-                }
-            }
-        },
-        "internal_server_endpoints.TTSConfigResponse": {
-            "type": "object",
-            "properties": {
-                "default_format": {
-                    "type": "string"
-                },
-                "default_voice": {
-                    "type": "string"
-                },
-                "formats": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "model": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "voice_cloning_url": {
-                    "type": "string"
-                },
-                "voices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.TTSVoice"
-                    }
-                }
-            }
-        },
-        "internal_server_endpoints.TTSVoice": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "voice_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ToCEntry": {
-            "type": "object",
-            "properties": {
-                "actual_page_num": {
-                    "type": "integer"
-                },
-                "entry_number": {
-                    "type": "string"
-                },
-                "is_linked": {
-                    "type": "boolean"
-                },
-                "level": {
-                    "type": "integer"
-                },
-                "level_name": {
-                    "type": "string"
-                },
-                "printed_page_number": {
-                    "type": "string"
-                },
-                "sort_order": {
-                    "type": "integer"
-                },
-                "source": {
-                    "description": "\"extracted\" or \"discovered\"",
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.ToCStatus": {
-            "type": "object",
-            "properties": {
-                "cost_usd": {
-                    "type": "number"
-                },
-                "discover_complete": {
-                    "description": "All entries discovered",
-                    "type": "boolean"
-                },
-                "end_page": {
-                    "type": "integer"
-                },
-                "entries": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/internal_server_endpoints.ToCEntry"
-                    }
-                },
-                "entries_discovered": {
-                    "description": "Actually discovered (source=\"discovered\")",
-                    "type": "integer"
-                },
-                "entries_linked": {
-                    "type": "integer"
-                },
-                "entries_to_find": {
-                    "description": "From pattern analysis (how many should be discovered)",
-                    "type": "integer"
-                },
-                "entry_count": {
-                    "description": "Entries (when extracted)",
-                    "type": "integer"
-                },
-                "excluded_ranges": {
-                    "description": "Number of excluded page ranges",
-                    "type": "integer"
-                },
-                "extract_complete": {
-                    "type": "boolean"
-                },
-                "extract_failed": {
-                    "type": "boolean"
-                },
-                "extract_started": {
-                    "description": "Extract stage",
-                    "type": "boolean"
-                },
-                "finalize_complete": {
-                    "type": "boolean"
-                },
-                "finalize_failed": {
-                    "type": "boolean"
-                },
-                "finalize_retries": {
-                    "type": "integer"
-                },
-                "finalize_started": {
-                    "description": "Finalize stage (overall)",
-                    "type": "boolean"
-                },
-                "finder_complete": {
-                    "type": "boolean"
-                },
-                "finder_failed": {
-                    "type": "boolean"
-                },
-                "finder_started": {
-                    "description": "Finder stage",
-                    "type": "boolean"
-                },
-                "found": {
-                    "type": "boolean"
-                },
-                "link_complete": {
-                    "type": "boolean"
-                },
-                "link_failed": {
-                    "type": "boolean"
-                },
-                "link_retries": {
-                    "type": "integer"
-                },
-                "link_started": {
-                    "description": "Link stage",
-                    "type": "boolean"
-                },
-                "pattern_analysis": {
-                    "description": "Full pattern analysis result",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/internal_server_endpoints.PatternAnalysisResult"
-                        }
-                    ]
-                },
-                "pattern_complete": {
-                    "description": "Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation",
-                    "type": "boolean"
-                },
-                "patterns_found": {
-                    "description": "Number of patterns discovered",
-                    "type": "integer"
-                },
-                "start_page": {
-                    "type": "integer"
-                },
-                "validate_complete": {
-                    "description": "Gap validation done (same as FinalizeComplete for now)",
-                    "type": "boolean"
-                }
-            }
-        },
-        "internal_server_endpoints.UpdateJobRequest": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {}
-                },
-                "status": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_server_endpoints.UpdateSettingRequest": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "value": {}
-            }
-        },
-        "internal_server_endpoints.VoiceResponse": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "is_default": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "synced_at": {
-                    "type": "string"
-                },
-                "voice_id": {
-                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1,5 +1,1022 @@
 basePath: /
 definitions:
+  endpoints.AgentLogDetailResponse:
+    properties:
+      agent_type:
+        type: string
+      book_id:
+        type: string
+      completed_at:
+        type: string
+      error:
+        type: string
+      id:
+        type: string
+      iterations:
+        type: integer
+      job_id:
+        type: string
+      messages:
+        description: Detailed data
+        items:
+          type: integer
+        type: array
+      result:
+        items:
+          type: integer
+        type: array
+      started_at:
+        type: string
+      success:
+        type: boolean
+      tool_calls:
+        items:
+          type: integer
+        type: array
+    type: object
+  endpoints.AgentLogSummary:
+    properties:
+      agent_type:
+        type: string
+      completed_at:
+        type: string
+      error:
+        type: string
+      id:
+        type: string
+      iterations:
+        type: integer
+      started_at:
+        type: string
+      success:
+        type: boolean
+    type: object
+  endpoints.AgentLogSummaryResponse:
+    properties:
+      agent_type:
+        type: string
+      book_id:
+        type: string
+      completed_at:
+        type: string
+      error:
+        type: string
+      id:
+        type: string
+      iterations:
+        type: integer
+      job_id:
+        type: string
+      started_at:
+        type: string
+      success:
+        type: boolean
+    type: object
+  endpoints.AgentLogsListResponse:
+    properties:
+      logs:
+        items:
+          $ref: '#/definitions/endpoints.AgentLogSummaryResponse'
+        type: array
+    type: object
+  endpoints.AudioStatusResponse:
+    properties:
+      book_id:
+        type: string
+      chapter_count:
+        type: integer
+      chapters:
+        items:
+          $ref: '#/definitions/endpoints.ChapterAudioStatus'
+        type: array
+      format:
+        type: string
+      provider:
+        type: string
+      segment_count:
+        type: integer
+      status:
+        type: string
+      total_cost_usd:
+        type: number
+      total_duration_ms:
+        type: integer
+      voice:
+        type: string
+    type: object
+  endpoints.Book:
+    properties:
+      author:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      page_count:
+        type: integer
+      page_pattern_analysis_json:
+        type: string
+      status:
+        type: string
+      title:
+        type: string
+    type: object
+  endpoints.BookMetadata:
+    properties:
+      author:
+        type: string
+      authors:
+        items:
+          type: string
+        type: array
+      description:
+        type: string
+      isbn:
+        type: string
+      language:
+        type: string
+      lccn:
+        type: string
+      publication_year:
+        type: integer
+      publisher:
+        type: string
+      subjects:
+        items:
+          type: string
+        type: array
+      title:
+        type: string
+    type: object
+  endpoints.BookPromptResponse:
+    properties:
+      cid:
+        type: string
+      is_override:
+        type: boolean
+      key:
+        type: string
+      text:
+        type: string
+      variables:
+        items:
+          type: string
+        type: array
+    type: object
+  endpoints.BookPromptsListResponse:
+    properties:
+      book_id:
+        type: string
+      prompts:
+        items:
+          $ref: '#/definitions/endpoints.BookPromptResponse'
+        type: array
+    type: object
+  endpoints.ChapterAudioStatus:
+    properties:
+      audio_file:
+        type: string
+      chapter_idx:
+        type: integer
+      cost_usd:
+        type: number
+      download_url:
+        type: string
+      duration_ms:
+        type: integer
+      segment_count:
+        type: integer
+      title:
+        type: string
+    type: object
+  endpoints.ChapterPage:
+    properties:
+      ocr_markdown:
+        type: string
+      page_num:
+        type: integer
+    type: object
+  endpoints.ChapterParagraph:
+    properties:
+      id:
+        type: string
+      polished_text:
+        type: string
+      raw_text:
+        type: string
+      sort_order:
+        type: integer
+      start_page:
+        type: integer
+      word_count:
+        type: integer
+    type: object
+  endpoints.ChapterWithText:
+    properties:
+      audio_include:
+        type: boolean
+      audio_include_reasoning:
+        type: string
+      classification_reasoning:
+        type: string
+      content_type:
+        type: string
+      edits_applied_json:
+        type: string
+      end_page:
+        type: integer
+      entry_id:
+        type: string
+      entry_number:
+        type: string
+      id:
+        type: string
+      level:
+        type: integer
+      level_name:
+        type: string
+      matter_type:
+        type: string
+      page_count:
+        type: integer
+      pages:
+        items:
+          $ref: '#/definitions/endpoints.ChapterPage'
+        type: array
+      paragraphs:
+        items:
+          $ref: '#/definitions/endpoints.ChapterParagraph'
+        type: array
+      polish_complete:
+        type: boolean
+      polish_failed:
+        type: boolean
+      polished_text:
+        type: string
+      sort_order:
+        type: integer
+      start_page:
+        type: integer
+      title:
+        type: string
+      word_count:
+        type: integer
+    type: object
+  endpoints.ChaptersResponse:
+    properties:
+      book_id:
+        type: string
+      book_title:
+        type: string
+      chapters:
+        items:
+          $ref: '#/definitions/endpoints.ChapterWithText'
+        type: array
+      has_chapters:
+        type: boolean
+      total_pages:
+        type: integer
+    type: object
+  endpoints.CreateJobRequest:
+    properties:
+      job_type:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+    type: object
+  endpoints.CreateJobResponse:
+    properties:
+      id:
+        type: string
+    type: object
+  endpoints.CreateVoiceRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      voice_id:
+        type: string
+    type: object
+  endpoints.DefraStatus:
+    properties:
+      container:
+        type: string
+      health:
+        type: string
+      url:
+        type: string
+    type: object
+  endpoints.DetailedJobStatusResponse:
+    properties:
+      agent_logs:
+        description: Agent logs summary
+        items:
+          $ref: '#/definitions/endpoints.AgentLogSummary'
+        type: array
+      book_id:
+        type: string
+      metadata:
+        allOf:
+        - $ref: '#/definitions/endpoints.MetadataStatus'
+        description: Metadata status
+      ocr_progress:
+        additionalProperties:
+          $ref: '#/definitions/endpoints.ProviderProgress'
+        description: Per-provider OCR progress
+        type: object
+      stages:
+        allOf:
+        - $ref: '#/definitions/endpoints.StageProgress'
+        description: Stage progress with costs
+      structure:
+        allOf:
+        - $ref: '#/definitions/endpoints.StructureStatus'
+        description: Structure status (common-structure job)
+      toc:
+        allOf:
+        - $ref: '#/definitions/endpoints.ToCStatus'
+        description: ToC status
+      total_pages:
+        type: integer
+    type: object
+  endpoints.DiscoveredPattern:
+    properties:
+      heading_format:
+        type: string
+      level:
+        type: integer
+      level_name:
+        type: string
+      pattern_type:
+        type: string
+      range_end:
+        type: string
+      range_start:
+        type: string
+      reasoning:
+        type: string
+    type: object
+  endpoints.EpubExportResponse:
+    properties:
+      author:
+        type: string
+      book_id:
+        type: string
+      chapter_count:
+        type: integer
+      created_at:
+        type: string
+      download_url:
+        type: string
+      file_path:
+        type: string
+      file_size:
+        type: integer
+      title:
+        type: string
+    type: object
+  endpoints.ErrorResponse:
+    properties:
+      error:
+        type: string
+    type: object
+  endpoints.ExcludedRange:
+    properties:
+      end_page:
+        type: integer
+      reason:
+        type: string
+      start_page:
+        type: integer
+    type: object
+  endpoints.GenerateAudioRequest:
+    properties:
+      format:
+        description: 'Optional: output format (mp3, wav)'
+        type: string
+      voice:
+        description: 'Optional: voice ID'
+        type: string
+    type: object
+  endpoints.GenerateAudioResponse:
+    properties:
+      book_id:
+        type: string
+      chapters:
+        type: integer
+      job_id:
+        type: string
+      provider:
+        type: string
+      status:
+        type: string
+    type: object
+  endpoints.GetJobResponse:
+    properties:
+      _docID:
+        type: string
+      book_id:
+        type: string
+      completed_at:
+        type: string
+      created_at:
+        type: string
+      error:
+        type: string
+      job_type:
+        type: string
+      live_status:
+        additionalProperties:
+          type: string
+        description: Live status fields (only populated for running jobs)
+        type: object
+      metadata:
+        additionalProperties: {}
+        type: object
+      pending_units:
+        type: integer
+      progress:
+        additionalProperties:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress'
+        type: object
+      started_at:
+        type: string
+      status:
+        $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.Status'
+      worker_status:
+        additionalProperties:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo'
+        type: object
+    type: object
+  endpoints.GetPageResponse:
+    properties:
+      ocr_markdown:
+        type: string
+      ocr_results:
+        items:
+          $ref: '#/definitions/endpoints.OcrResult'
+        type: array
+      page_num:
+        type: integer
+      status:
+        $ref: '#/definitions/endpoints.PageStatus'
+    type: object
+  endpoints.HealthResponse:
+    properties:
+      defra:
+        type: string
+      status:
+        type: string
+    type: object
+  endpoints.IngestRequest:
+    properties:
+      author:
+        type: string
+      pdf_paths:
+        items:
+          type: string
+        type: array
+      title:
+        type: string
+    type: object
+  endpoints.IngestResponse:
+    properties:
+      author:
+        type: string
+      book_id:
+        type: string
+      job_id:
+        type: string
+      process_job_id:
+        type: string
+      status:
+        type: string
+      title:
+        type: string
+    type: object
+  endpoints.JobStatusResponse:
+    properties:
+      book_id:
+        type: string
+      is_complete:
+        type: boolean
+      job_type:
+        type: string
+      metadata_complete:
+        type: boolean
+      ocr_complete:
+        type: integer
+      toc_extracted:
+        type: boolean
+      toc_found:
+        type: boolean
+      total_pages:
+        type: integer
+    type: object
+  endpoints.LLMCallCountsResponse:
+    properties:
+      counts:
+        additionalProperties:
+          type: integer
+        type: object
+    type: object
+  endpoints.LLMCallResponse:
+    properties:
+      call:
+        $ref: '#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call'
+      error:
+        type: string
+    type: object
+  endpoints.LLMCallsResponse:
+    properties:
+      calls:
+        items:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call'
+        type: array
+      total:
+        type: integer
+    type: object
+  endpoints.ListBooksResponse:
+    properties:
+      books:
+        items:
+          $ref: '#/definitions/endpoints.Book'
+        type: array
+    type: object
+  endpoints.ListJobsResponse:
+    properties:
+      jobs:
+        items:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.Record'
+        type: array
+    type: object
+  endpoints.ListMetricsResponse:
+    properties:
+      count:
+        type: integer
+      metrics:
+        items:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_metrics.Metric'
+        type: array
+    type: object
+  endpoints.ListPagesResponse:
+    properties:
+      pages:
+        items:
+          $ref: '#/definitions/endpoints.PageSummary'
+        type: array
+      total_pages:
+        type: integer
+    type: object
+  endpoints.ListVoicesResponse:
+    properties:
+      voices:
+        items:
+          $ref: '#/definitions/endpoints.VoiceResponse'
+        type: array
+    type: object
+  endpoints.MetadataStatus:
+    properties:
+      complete:
+        type: boolean
+      cost_usd:
+        type: number
+      data:
+        $ref: '#/definitions/endpoints.BookMetadata'
+      failed:
+        type: boolean
+      started:
+        type: boolean
+    type: object
+  endpoints.MetricsCostResponse:
+    properties:
+      breakdown:
+        additionalProperties:
+          format: float64
+          type: number
+        type: object
+      total_cost_usd:
+        type: number
+    type: object
+  endpoints.MetricsDetailedResponse:
+    properties:
+      book_id:
+        type: string
+      stages:
+        additionalProperties:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_metrics.DetailedStats'
+        type: object
+    type: object
+  endpoints.MetricsSummaryResponse:
+    properties:
+      avg_cost_usd:
+        type: number
+      avg_time_seconds:
+        type: number
+      avg_tokens:
+        type: number
+      count:
+        type: integer
+      error_count:
+        type: integer
+      success_count:
+        type: integer
+      total_cost_usd:
+        type: number
+      total_time_seconds:
+        type: number
+      total_tokens:
+        type: integer
+    type: object
+  endpoints.OcrResult:
+    properties:
+      confidence:
+        type: number
+      provider:
+        type: string
+      text:
+        type: string
+    type: object
+  endpoints.PageStatus:
+    properties:
+      extract_complete:
+        type: boolean
+      ocr_complete:
+        type: boolean
+    type: object
+  endpoints.PageSummary:
+    properties:
+      ocr_complete:
+        type: boolean
+      page_num:
+        type: integer
+    type: object
+  endpoints.PatternAnalysisResult:
+    properties:
+      excluded_ranges:
+        items:
+          $ref: '#/definitions/endpoints.ExcludedRange'
+        type: array
+      patterns:
+        items:
+          $ref: '#/definitions/endpoints.DiscoveredPattern'
+        type: array
+      reasoning:
+        type: string
+    type: object
+  endpoints.PromptResponse:
+    properties:
+      description:
+        type: string
+      doc_id:
+        type: string
+      hash:
+        type: string
+      key:
+        type: string
+      text:
+        type: string
+      variables:
+        items:
+          type: string
+        type: array
+    type: object
+  endpoints.PromptsListResponse:
+    properties:
+      prompts:
+        items:
+          $ref: '#/definitions/endpoints.PromptResponse'
+        type: array
+    type: object
+  endpoints.ProviderProgress:
+    properties:
+      complete:
+        type: integer
+      cost_usd:
+        type: number
+      total:
+        type: integer
+    type: object
+  endpoints.ProvidersStatus:
+    properties:
+      llm:
+        items:
+          type: string
+        type: array
+      ocr:
+        items:
+          type: string
+        type: array
+    type: object
+  endpoints.RerunTocResponse:
+    properties:
+      job_id:
+        type: string
+      message:
+        type: string
+    type: object
+  endpoints.SetPromptRequest:
+    properties:
+      note:
+        type: string
+      text:
+        type: string
+    type: object
+  endpoints.SettingResponse:
+    properties:
+      entry:
+        $ref: '#/definitions/github_com_jackzampolin_shelf_internal_config.Entry'
+      error:
+        type: string
+    type: object
+  endpoints.SettingsResponse:
+    properties:
+      settings:
+        additionalProperties:
+          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_config.Entry'
+        type: object
+    type: object
+  endpoints.StageProgress:
+    properties:
+      ocr:
+        properties:
+          complete:
+            type: integer
+          cost_by_provider:
+            additionalProperties:
+              format: float64
+              type: number
+            type: object
+          total:
+            type: integer
+          total_cost_usd:
+            type: number
+        type: object
+      pattern_analysis:
+        properties:
+          complete:
+            type: boolean
+          cost_usd:
+            type: number
+        type: object
+    type: object
+  endpoints.StartJobRequest:
+    properties:
+      force:
+        description: 'Optional: force restart even if already complete'
+        type: boolean
+      job_type:
+        description: 'Optional: defaults to "process-book"'
+        type: string
+      reset_from:
+        description: 'Optional: reset this operation and downstream deps before starting'
+        type: string
+      variant:
+        description: 'Optional: pipeline variant (standard, photo-book, text-only,
+          ocr-only)'
+        type: string
+    type: object
+  endpoints.StartJobResponse:
+    properties:
+      book_id:
+        type: string
+      job_id:
+        type: string
+      job_type:
+        type: string
+      status:
+        type: string
+    type: object
+  endpoints.StatusResponse:
+    properties:
+      defra:
+        $ref: '#/definitions/endpoints.DefraStatus'
+      providers:
+        $ref: '#/definitions/endpoints.ProvidersStatus'
+      server:
+        type: string
+    type: object
+  endpoints.StorytellerExportResponse:
+    properties:
+      audio_chapters:
+        type: integer
+      author:
+        type: string
+      book_id:
+        type: string
+      chapter_count:
+        type: integer
+      created_at:
+        type: string
+      download_url:
+        type: string
+      file_path:
+        type: string
+      file_size:
+        type: integer
+      title:
+        type: string
+      total_duration_ms:
+        type: integer
+    type: object
+  endpoints.StructureStatus:
+    properties:
+      chapter_count:
+        type: integer
+      chapters_extracted:
+        type: integer
+      chapters_polished:
+        type: integer
+      chapters_total:
+        type: integer
+      complete:
+        type: boolean
+      cost_usd:
+        type: number
+      failed:
+        type: boolean
+      phase:
+        description: Phase tracking (build -> extract -> classify -> polish -> finalize)
+        type: string
+      polish_failed:
+        type: integer
+      retries:
+        type: integer
+      started:
+        type: boolean
+    type: object
+  endpoints.SyncVoicesResponse:
+    properties:
+      message:
+        type: string
+      synced:
+        type: integer
+    type: object
+  endpoints.TTSConfigResponse:
+    properties:
+      default_format:
+        type: string
+      default_voice:
+        type: string
+      formats:
+        items:
+          type: string
+        type: array
+      model:
+        type: string
+      provider:
+        type: string
+      voice_cloning_url:
+        type: string
+      voices:
+        items:
+          $ref: '#/definitions/endpoints.TTSVoice'
+        type: array
+    type: object
+  endpoints.TTSVoice:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      voice_id:
+        type: string
+    type: object
+  endpoints.ToCEntry:
+    properties:
+      actual_page_num:
+        type: integer
+      entry_number:
+        type: string
+      is_linked:
+        type: boolean
+      level:
+        type: integer
+      level_name:
+        type: string
+      printed_page_number:
+        type: string
+      sort_order:
+        type: integer
+      source:
+        description: '"extracted" or "discovered"'
+        type: string
+      title:
+        type: string
+    type: object
+  endpoints.ToCStatus:
+    properties:
+      cost_usd:
+        type: number
+      discover_complete:
+        description: All entries discovered
+        type: boolean
+      end_page:
+        type: integer
+      entries:
+        items:
+          $ref: '#/definitions/endpoints.ToCEntry'
+        type: array
+      entries_discovered:
+        description: Actually discovered (source="discovered")
+        type: integer
+      entries_linked:
+        type: integer
+      entries_to_find:
+        description: From pattern analysis (how many should be discovered)
+        type: integer
+      entry_count:
+        description: Entries (when extracted)
+        type: integer
+      excluded_ranges:
+        description: Number of excluded page ranges
+        type: integer
+      extract_complete:
+        type: boolean
+      extract_failed:
+        type: boolean
+      extract_started:
+        description: Extract stage
+        type: boolean
+      finalize_complete:
+        type: boolean
+      finalize_failed:
+        type: boolean
+      finalize_retries:
+        type: integer
+      finalize_started:
+        description: Finalize stage (overall)
+        type: boolean
+      finder_complete:
+        type: boolean
+      finder_failed:
+        type: boolean
+      finder_started:
+        description: Finder stage
+        type: boolean
+      found:
+        type: boolean
+      link_complete:
+        type: boolean
+      link_failed:
+        type: boolean
+      link_retries:
+        type: integer
+      link_started:
+        description: Link stage
+        type: boolean
+      pattern_analysis:
+        allOf:
+        - $ref: '#/definitions/endpoints.PatternAnalysisResult'
+        description: Full pattern analysis result
+      pattern_complete:
+        description: 'Finalize sub-phases: Pattern Analysis → Chapter Discovery →
+          Gap Validation'
+        type: boolean
+      patterns_found:
+        description: Number of patterns discovered
+        type: integer
+      start_page:
+        type: integer
+      validate_complete:
+        description: Gap validation done (same as FinalizeComplete for now)
+        type: boolean
+    type: object
+  endpoints.UpdateJobRequest:
+    properties:
+      error:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      status:
+        type: string
+    type: object
+  endpoints.UpdateSettingRequest:
+    properties:
+      description:
+        type: string
+      value: {}
+    type: object
+  endpoints.VoiceResponse:
+    properties:
+      created_at:
+        type: string
+      description:
+        type: string
+      is_default:
+        type: boolean
+      name:
+        type: string
+      provider:
+        type: string
+      synced_at:
+        type: string
+      voice_id:
+        type: string
+    type: object
   github_com_jackzampolin_shelf_internal_config.Entry:
     properties:
       _docID:
@@ -240,1017 +1257,6 @@ definitions:
       total_tokens:
         type: integer
     type: object
-  internal_server_endpoints.AgentLogDetailResponse:
-    properties:
-      agent_type:
-        type: string
-      book_id:
-        type: string
-      completed_at:
-        type: string
-      error:
-        type: string
-      id:
-        type: string
-      iterations:
-        type: integer
-      job_id:
-        type: string
-      messages:
-        description: Detailed data
-        items:
-          type: integer
-        type: array
-      result:
-        items:
-          type: integer
-        type: array
-      started_at:
-        type: string
-      success:
-        type: boolean
-      tool_calls:
-        items:
-          type: integer
-        type: array
-    type: object
-  internal_server_endpoints.AgentLogSummary:
-    properties:
-      agent_type:
-        type: string
-      completed_at:
-        type: string
-      error:
-        type: string
-      id:
-        type: string
-      iterations:
-        type: integer
-      started_at:
-        type: string
-      success:
-        type: boolean
-    type: object
-  internal_server_endpoints.AgentLogSummaryResponse:
-    properties:
-      agent_type:
-        type: string
-      book_id:
-        type: string
-      completed_at:
-        type: string
-      error:
-        type: string
-      id:
-        type: string
-      iterations:
-        type: integer
-      job_id:
-        type: string
-      started_at:
-        type: string
-      success:
-        type: boolean
-    type: object
-  internal_server_endpoints.AgentLogsListResponse:
-    properties:
-      logs:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.AgentLogSummaryResponse'
-        type: array
-    type: object
-  internal_server_endpoints.AudioStatusResponse:
-    properties:
-      book_id:
-        type: string
-      chapter_count:
-        type: integer
-      chapters:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.ChapterAudioStatus'
-        type: array
-      format:
-        type: string
-      provider:
-        type: string
-      segment_count:
-        type: integer
-      status:
-        type: string
-      total_cost_usd:
-        type: number
-      total_duration_ms:
-        type: integer
-      voice:
-        type: string
-    type: object
-  internal_server_endpoints.Book:
-    properties:
-      author:
-        type: string
-      created_at:
-        type: string
-      id:
-        type: string
-      page_count:
-        type: integer
-      page_pattern_analysis_json:
-        type: string
-      status:
-        type: string
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.BookMetadata:
-    properties:
-      author:
-        type: string
-      authors:
-        items:
-          type: string
-        type: array
-      description:
-        type: string
-      isbn:
-        type: string
-      language:
-        type: string
-      lccn:
-        type: string
-      publication_year:
-        type: integer
-      publisher:
-        type: string
-      subjects:
-        items:
-          type: string
-        type: array
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.BookPromptResponse:
-    properties:
-      cid:
-        type: string
-      is_override:
-        type: boolean
-      key:
-        type: string
-      text:
-        type: string
-      variables:
-        items:
-          type: string
-        type: array
-    type: object
-  internal_server_endpoints.BookPromptsListResponse:
-    properties:
-      book_id:
-        type: string
-      prompts:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.BookPromptResponse'
-        type: array
-    type: object
-  internal_server_endpoints.ChapterAudioStatus:
-    properties:
-      audio_file:
-        type: string
-      chapter_idx:
-        type: integer
-      cost_usd:
-        type: number
-      download_url:
-        type: string
-      duration_ms:
-        type: integer
-      segment_count:
-        type: integer
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.ChapterPage:
-    properties:
-      ocr_markdown:
-        type: string
-      page_num:
-        type: integer
-    type: object
-  internal_server_endpoints.ChapterParagraph:
-    properties:
-      id:
-        type: string
-      polished_text:
-        type: string
-      raw_text:
-        type: string
-      sort_order:
-        type: integer
-      start_page:
-        type: integer
-      word_count:
-        type: integer
-    type: object
-  internal_server_endpoints.ChapterWithText:
-    properties:
-      classification_reasoning:
-        type: string
-      edits_applied_json:
-        type: string
-      end_page:
-        type: integer
-      entry_id:
-        type: string
-      entry_number:
-        type: string
-      id:
-        type: string
-      level:
-        type: integer
-      level_name:
-        type: string
-      matter_type:
-        type: string
-      page_count:
-        type: integer
-      pages:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.ChapterPage'
-        type: array
-      paragraphs:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.ChapterParagraph'
-        type: array
-      polish_complete:
-        type: boolean
-      polish_failed:
-        type: boolean
-      polished_text:
-        type: string
-      sort_order:
-        type: integer
-      start_page:
-        type: integer
-      title:
-        type: string
-      word_count:
-        type: integer
-    type: object
-  internal_server_endpoints.ChaptersResponse:
-    properties:
-      book_id:
-        type: string
-      book_title:
-        type: string
-      chapters:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.ChapterWithText'
-        type: array
-      has_chapters:
-        type: boolean
-      total_pages:
-        type: integer
-    type: object
-  internal_server_endpoints.CreateJobRequest:
-    properties:
-      job_type:
-        type: string
-      metadata:
-        additionalProperties: {}
-        type: object
-    type: object
-  internal_server_endpoints.CreateJobResponse:
-    properties:
-      id:
-        type: string
-    type: object
-  internal_server_endpoints.CreateVoiceRequest:
-    properties:
-      description:
-        type: string
-      name:
-        type: string
-      voice_id:
-        type: string
-    type: object
-  internal_server_endpoints.DefraStatus:
-    properties:
-      container:
-        type: string
-      health:
-        type: string
-      url:
-        type: string
-    type: object
-  internal_server_endpoints.DetailedJobStatusResponse:
-    properties:
-      agent_logs:
-        description: Agent logs summary
-        items:
-          $ref: '#/definitions/internal_server_endpoints.AgentLogSummary'
-        type: array
-      book_id:
-        type: string
-      metadata:
-        allOf:
-        - $ref: '#/definitions/internal_server_endpoints.MetadataStatus'
-        description: Metadata status
-      ocr_progress:
-        additionalProperties:
-          $ref: '#/definitions/internal_server_endpoints.ProviderProgress'
-        description: Per-provider OCR progress
-        type: object
-      stages:
-        allOf:
-        - $ref: '#/definitions/internal_server_endpoints.StageProgress'
-        description: Stage progress with costs
-      structure:
-        allOf:
-        - $ref: '#/definitions/internal_server_endpoints.StructureStatus'
-        description: Structure status (common-structure job)
-      toc:
-        allOf:
-        - $ref: '#/definitions/internal_server_endpoints.ToCStatus'
-        description: ToC status
-      total_pages:
-        type: integer
-    type: object
-  internal_server_endpoints.DiscoveredPattern:
-    properties:
-      heading_format:
-        type: string
-      level:
-        type: integer
-      level_name:
-        type: string
-      pattern_type:
-        type: string
-      range_end:
-        type: string
-      range_start:
-        type: string
-      reasoning:
-        type: string
-    type: object
-  internal_server_endpoints.EpubExportResponse:
-    properties:
-      author:
-        type: string
-      book_id:
-        type: string
-      chapter_count:
-        type: integer
-      created_at:
-        type: string
-      download_url:
-        type: string
-      file_path:
-        type: string
-      file_size:
-        type: integer
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.ErrorResponse:
-    properties:
-      error:
-        type: string
-    type: object
-  internal_server_endpoints.ExcludedRange:
-    properties:
-      end_page:
-        type: integer
-      reason:
-        type: string
-      start_page:
-        type: integer
-    type: object
-  internal_server_endpoints.GenerateAudioRequest:
-    properties:
-      format:
-        description: 'Optional: output format (mp3, wav)'
-        type: string
-      voice:
-        description: 'Optional: voice ID'
-        type: string
-    type: object
-  internal_server_endpoints.GenerateAudioResponse:
-    properties:
-      book_id:
-        type: string
-      chapters:
-        type: integer
-      job_id:
-        type: string
-      provider:
-        type: string
-      status:
-        type: string
-    type: object
-  internal_server_endpoints.GetJobResponse:
-    properties:
-      _docID:
-        type: string
-      book_id:
-        type: string
-      completed_at:
-        type: string
-      created_at:
-        type: string
-      error:
-        type: string
-      job_type:
-        type: string
-      live_status:
-        additionalProperties:
-          type: string
-        description: Live status fields (only populated for running jobs)
-        type: object
-      metadata:
-        additionalProperties: {}
-        type: object
-      pending_units:
-        type: integer
-      progress:
-        additionalProperties:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.ProviderProgress'
-        type: object
-      started_at:
-        type: string
-      status:
-        $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.Status'
-      worker_status:
-        additionalProperties:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo'
-        type: object
-    type: object
-  internal_server_endpoints.GetPageResponse:
-    properties:
-      ocr_markdown:
-        type: string
-      ocr_results:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.OcrResult'
-        type: array
-      page_num:
-        type: integer
-      status:
-        $ref: '#/definitions/internal_server_endpoints.PageStatus'
-    type: object
-  internal_server_endpoints.HealthResponse:
-    properties:
-      defra:
-        type: string
-      status:
-        type: string
-    type: object
-  internal_server_endpoints.IngestRequest:
-    properties:
-      author:
-        type: string
-      pdf_paths:
-        items:
-          type: string
-        type: array
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.IngestResponse:
-    properties:
-      author:
-        type: string
-      book_id:
-        type: string
-      job_id:
-        type: string
-      process_job_id:
-        type: string
-      status:
-        type: string
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.JobStatusResponse:
-    properties:
-      book_id:
-        type: string
-      is_complete:
-        type: boolean
-      job_type:
-        type: string
-      metadata_complete:
-        type: boolean
-      ocr_complete:
-        type: integer
-      toc_extracted:
-        type: boolean
-      toc_found:
-        type: boolean
-      total_pages:
-        type: integer
-    type: object
-  internal_server_endpoints.LLMCallCountsResponse:
-    properties:
-      counts:
-        additionalProperties:
-          type: integer
-        type: object
-    type: object
-  internal_server_endpoints.LLMCallResponse:
-    properties:
-      call:
-        $ref: '#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call'
-      error:
-        type: string
-    type: object
-  internal_server_endpoints.LLMCallsResponse:
-    properties:
-      calls:
-        items:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_llmcall.Call'
-        type: array
-      total:
-        type: integer
-    type: object
-  internal_server_endpoints.ListBooksResponse:
-    properties:
-      books:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.Book'
-        type: array
-    type: object
-  internal_server_endpoints.ListJobsResponse:
-    properties:
-      jobs:
-        items:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_jobs.Record'
-        type: array
-    type: object
-  internal_server_endpoints.ListMetricsResponse:
-    properties:
-      count:
-        type: integer
-      metrics:
-        items:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_metrics.Metric'
-        type: array
-    type: object
-  internal_server_endpoints.ListPagesResponse:
-    properties:
-      pages:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.PageSummary'
-        type: array
-      total_pages:
-        type: integer
-    type: object
-  internal_server_endpoints.ListVoicesResponse:
-    properties:
-      voices:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.VoiceResponse'
-        type: array
-    type: object
-  internal_server_endpoints.MetadataStatus:
-    properties:
-      complete:
-        type: boolean
-      cost_usd:
-        type: number
-      data:
-        $ref: '#/definitions/internal_server_endpoints.BookMetadata'
-      failed:
-        type: boolean
-      started:
-        type: boolean
-    type: object
-  internal_server_endpoints.MetricsCostResponse:
-    properties:
-      breakdown:
-        additionalProperties:
-          format: float64
-          type: number
-        type: object
-      total_cost_usd:
-        type: number
-    type: object
-  internal_server_endpoints.MetricsDetailedResponse:
-    properties:
-      book_id:
-        type: string
-      stages:
-        additionalProperties:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_metrics.DetailedStats'
-        type: object
-    type: object
-  internal_server_endpoints.MetricsSummaryResponse:
-    properties:
-      avg_cost_usd:
-        type: number
-      avg_time_seconds:
-        type: number
-      avg_tokens:
-        type: number
-      count:
-        type: integer
-      error_count:
-        type: integer
-      success_count:
-        type: integer
-      total_cost_usd:
-        type: number
-      total_time_seconds:
-        type: number
-      total_tokens:
-        type: integer
-    type: object
-  internal_server_endpoints.OcrResult:
-    properties:
-      confidence:
-        type: number
-      provider:
-        type: string
-      text:
-        type: string
-    type: object
-  internal_server_endpoints.PageStatus:
-    properties:
-      extract_complete:
-        type: boolean
-      ocr_complete:
-        type: boolean
-    type: object
-  internal_server_endpoints.PageSummary:
-    properties:
-      ocr_complete:
-        type: boolean
-      page_num:
-        type: integer
-    type: object
-  internal_server_endpoints.PatternAnalysisResult:
-    properties:
-      excluded_ranges:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.ExcludedRange'
-        type: array
-      patterns:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.DiscoveredPattern'
-        type: array
-      reasoning:
-        type: string
-    type: object
-  internal_server_endpoints.PromptResponse:
-    properties:
-      description:
-        type: string
-      doc_id:
-        type: string
-      hash:
-        type: string
-      key:
-        type: string
-      text:
-        type: string
-      variables:
-        items:
-          type: string
-        type: array
-    type: object
-  internal_server_endpoints.PromptsListResponse:
-    properties:
-      prompts:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.PromptResponse'
-        type: array
-    type: object
-  internal_server_endpoints.ProviderProgress:
-    properties:
-      complete:
-        type: integer
-      cost_usd:
-        type: number
-      total:
-        type: integer
-    type: object
-  internal_server_endpoints.ProvidersStatus:
-    properties:
-      llm:
-        items:
-          type: string
-        type: array
-      ocr:
-        items:
-          type: string
-        type: array
-    type: object
-  internal_server_endpoints.RerunTocResponse:
-    properties:
-      job_id:
-        type: string
-      message:
-        type: string
-    type: object
-  internal_server_endpoints.SetPromptRequest:
-    properties:
-      note:
-        type: string
-      text:
-        type: string
-    type: object
-  internal_server_endpoints.SettingResponse:
-    properties:
-      entry:
-        $ref: '#/definitions/github_com_jackzampolin_shelf_internal_config.Entry'
-      error:
-        type: string
-    type: object
-  internal_server_endpoints.SettingsResponse:
-    properties:
-      settings:
-        additionalProperties:
-          $ref: '#/definitions/github_com_jackzampolin_shelf_internal_config.Entry'
-        type: object
-    type: object
-  internal_server_endpoints.StageProgress:
-    properties:
-      ocr:
-        properties:
-          complete:
-            type: integer
-          cost_by_provider:
-            additionalProperties:
-              format: float64
-              type: number
-            type: object
-          total:
-            type: integer
-          total_cost_usd:
-            type: number
-        type: object
-      pattern_analysis:
-        properties:
-          complete:
-            type: boolean
-          cost_usd:
-            type: number
-        type: object
-    type: object
-  internal_server_endpoints.StartJobRequest:
-    properties:
-      force:
-        description: 'Optional: force restart even if already complete'
-        type: boolean
-      job_type:
-        description: 'Optional: defaults to "process-book"'
-        type: string
-      reset_from:
-        description: 'Optional: reset this operation and downstream deps before starting'
-        type: string
-      variant:
-        description: 'Optional: pipeline variant (standard, photo-book, text-only,
-          ocr-only)'
-        type: string
-    type: object
-  internal_server_endpoints.StartJobResponse:
-    properties:
-      book_id:
-        type: string
-      job_id:
-        type: string
-      job_type:
-        type: string
-      status:
-        type: string
-    type: object
-  internal_server_endpoints.StatusResponse:
-    properties:
-      defra:
-        $ref: '#/definitions/internal_server_endpoints.DefraStatus'
-      providers:
-        $ref: '#/definitions/internal_server_endpoints.ProvidersStatus'
-      server:
-        type: string
-    type: object
-  internal_server_endpoints.StorytellerExportResponse:
-    properties:
-      audio_chapters:
-        type: integer
-      author:
-        type: string
-      book_id:
-        type: string
-      chapter_count:
-        type: integer
-      created_at:
-        type: string
-      download_url:
-        type: string
-      file_path:
-        type: string
-      file_size:
-        type: integer
-      title:
-        type: string
-      total_duration_ms:
-        type: integer
-    type: object
-  internal_server_endpoints.StructureStatus:
-    properties:
-      chapter_count:
-        type: integer
-      chapters_extracted:
-        type: integer
-      chapters_polished:
-        type: integer
-      chapters_total:
-        type: integer
-      complete:
-        type: boolean
-      cost_usd:
-        type: number
-      failed:
-        type: boolean
-      phase:
-        description: Phase tracking (build -> extract -> classify -> polish -> finalize)
-        type: string
-      polish_failed:
-        type: integer
-      retries:
-        type: integer
-      started:
-        type: boolean
-    type: object
-  internal_server_endpoints.SyncVoicesResponse:
-    properties:
-      message:
-        type: string
-      synced:
-        type: integer
-    type: object
-  internal_server_endpoints.TTSConfigResponse:
-    properties:
-      default_format:
-        type: string
-      default_voice:
-        type: string
-      formats:
-        items:
-          type: string
-        type: array
-      model:
-        type: string
-      provider:
-        type: string
-      voice_cloning_url:
-        type: string
-      voices:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.TTSVoice'
-        type: array
-    type: object
-  internal_server_endpoints.TTSVoice:
-    properties:
-      description:
-        type: string
-      name:
-        type: string
-      voice_id:
-        type: string
-    type: object
-  internal_server_endpoints.ToCEntry:
-    properties:
-      actual_page_num:
-        type: integer
-      entry_number:
-        type: string
-      is_linked:
-        type: boolean
-      level:
-        type: integer
-      level_name:
-        type: string
-      printed_page_number:
-        type: string
-      sort_order:
-        type: integer
-      source:
-        description: '"extracted" or "discovered"'
-        type: string
-      title:
-        type: string
-    type: object
-  internal_server_endpoints.ToCStatus:
-    properties:
-      cost_usd:
-        type: number
-      discover_complete:
-        description: All entries discovered
-        type: boolean
-      end_page:
-        type: integer
-      entries:
-        items:
-          $ref: '#/definitions/internal_server_endpoints.ToCEntry'
-        type: array
-      entries_discovered:
-        description: Actually discovered (source="discovered")
-        type: integer
-      entries_linked:
-        type: integer
-      entries_to_find:
-        description: From pattern analysis (how many should be discovered)
-        type: integer
-      entry_count:
-        description: Entries (when extracted)
-        type: integer
-      excluded_ranges:
-        description: Number of excluded page ranges
-        type: integer
-      extract_complete:
-        type: boolean
-      extract_failed:
-        type: boolean
-      extract_started:
-        description: Extract stage
-        type: boolean
-      finalize_complete:
-        type: boolean
-      finalize_failed:
-        type: boolean
-      finalize_retries:
-        type: integer
-      finalize_started:
-        description: Finalize stage (overall)
-        type: boolean
-      finder_complete:
-        type: boolean
-      finder_failed:
-        type: boolean
-      finder_started:
-        description: Finder stage
-        type: boolean
-      found:
-        type: boolean
-      link_complete:
-        type: boolean
-      link_failed:
-        type: boolean
-      link_retries:
-        type: integer
-      link_started:
-        description: Link stage
-        type: boolean
-      pattern_analysis:
-        allOf:
-        - $ref: '#/definitions/internal_server_endpoints.PatternAnalysisResult'
-        description: Full pattern analysis result
-      pattern_complete:
-        description: 'Finalize sub-phases: Pattern Analysis → Chapter Discovery →
-          Gap Validation'
-        type: boolean
-      patterns_found:
-        description: Number of patterns discovered
-        type: integer
-      start_page:
-        type: integer
-      validate_complete:
-        description: Gap validation done (same as FinalizeComplete for now)
-        type: boolean
-    type: object
-  internal_server_endpoints.UpdateJobRequest:
-    properties:
-      error:
-        type: string
-      metadata:
-        additionalProperties: {}
-        type: object
-      status:
-        type: string
-    type: object
-  internal_server_endpoints.UpdateSettingRequest:
-    properties:
-      description:
-        type: string
-      value: {}
-    type: object
-  internal_server_endpoints.VoiceResponse:
-    properties:
-      created_at:
-        type: string
-      description:
-        type: string
-      is_default:
-        type: boolean
-      name:
-        type: string
-      provider:
-        type: string
-      synced_at:
-        type: string
-      voice_id:
-        type: string
-    type: object
   time.Duration:
     enum:
     - -9223372036854775808
@@ -1299,23 +1305,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.AgentLogDetailResponse'
+            $ref: '#/definitions/endpoints.AgentLogDetailResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get agent log details
       tags:
       - agent-logs
@@ -1328,15 +1334,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ListBooksResponse'
+            $ref: '#/definitions/endpoints.ListBooksResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List books
       tags:
       - books
@@ -1368,19 +1374,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.AgentLogsListResponse'
+            $ref: '#/definitions/endpoints.AgentLogsListResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List agent logs for a book
       tags:
       - agent-logs
@@ -1399,19 +1405,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.AudioStatusResponse'
+            $ref: '#/definitions/endpoints.AudioStatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get audio status
       tags:
       - books
@@ -1440,11 +1446,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Download chapter audio
       tags:
       - books
@@ -1464,19 +1470,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.EpubExportResponse'
+            $ref: '#/definitions/endpoints.EpubExportResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Export book as ePub
       tags:
       - books
@@ -1500,11 +1506,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Download ePub file
       tags:
       - books
@@ -1525,19 +1531,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.StorytellerExportResponse'
+            $ref: '#/definitions/endpoints.StorytellerExportResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Export book as EPUB with Media Overlays for Storyteller
       tags:
       - books
@@ -1562,11 +1568,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Download Storyteller EPUB file
       tags:
       - books
@@ -1587,30 +1593,30 @@ paths:
         in: body
         name: request
         schema:
-          $ref: '#/definitions/internal_server_endpoints.GenerateAudioRequest'
+          $ref: '#/definitions/endpoints.GenerateAudioRequest'
       produces:
       - application/json
       responses:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/internal_server_endpoints.GenerateAudioResponse'
+            $ref: '#/definitions/endpoints.GenerateAudioResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Start TTS audio generation
       tags:
       - books
@@ -1630,19 +1636,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ListPagesResponse'
+            $ref: '#/definitions/endpoints.ListPagesResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List pages
       tags:
       - pages
@@ -1666,23 +1672,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.GetPageResponse'
+            $ref: '#/definitions/endpoints.GetPageResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get page details
       tags:
       - pages
@@ -1710,15 +1716,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get page image
       tags:
       - pages
@@ -1737,27 +1743,27 @@ paths:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/internal_server_endpoints.RerunTocResponse'
+            $ref: '#/definitions/endpoints.RerunTocResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "412":
           description: Not enough pages have OCR complete
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Rerun ToC finder and extractor
       tags:
       - books
@@ -1776,23 +1782,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.Book'
+            $ref: '#/definitions/endpoints.Book'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get book by ID
       tags:
       - books
@@ -1819,19 +1825,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ChaptersResponse'
+            $ref: '#/definitions/endpoints.ChaptersResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get book chapters
       tags:
       - books
@@ -1854,19 +1860,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.MetricsCostResponse'
+            $ref: '#/definitions/endpoints.MetricsCostResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get book processing cost
       tags:
       - books
@@ -1886,19 +1892,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.MetricsDetailedResponse'
+            $ref: '#/definitions/endpoints.MetricsDetailedResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get detailed book metrics with percentiles
       tags:
       - books
@@ -1918,11 +1924,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.BookPromptsListResponse'
+            $ref: '#/definitions/endpoints.BookPromptsListResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List prompts for a book
       tags:
       - prompts
@@ -1946,15 +1952,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.BookPromptResponse'
+            $ref: '#/definitions/endpoints.BookPromptResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Clear a book prompt override
       tags:
       - prompts
@@ -1977,15 +1983,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.BookPromptResponse'
+            $ref: '#/definitions/endpoints.BookPromptResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get a prompt for a book
       tags:
       - prompts
@@ -2009,22 +2015,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_server_endpoints.SetPromptRequest'
+          $ref: '#/definitions/endpoints.SetPromptRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.BookPromptResponse'
+            $ref: '#/definitions/endpoints.BookPromptResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Set a book prompt override
       tags:
       - prompts
@@ -2039,26 +2045,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/internal_server_endpoints.IngestRequest'
+          $ref: '#/definitions/endpoints.IngestRequest'
       produces:
       - application/json
       responses:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/internal_server_endpoints.IngestResponse'
+            $ref: '#/definitions/endpoints.IngestResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Ingest book scans
       tags:
       - books
@@ -2091,19 +2097,19 @@ paths:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/internal_server_endpoints.IngestResponse'
+            $ref: '#/definitions/endpoints.IngestResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Upload and ingest book PDFs
       tags:
       - books
@@ -2116,7 +2122,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.HealthResponse'
+            $ref: '#/definitions/endpoints.HealthResponse'
       summary: Health check
       tags:
       - health
@@ -2142,15 +2148,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ListJobsResponse'
+            $ref: '#/definitions/endpoints.ListJobsResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List jobs
       tags:
       - jobs
@@ -2164,26 +2170,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/internal_server_endpoints.CreateJobRequest'
+          $ref: '#/definitions/endpoints.CreateJobRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/internal_server_endpoints.CreateJobResponse'
+            $ref: '#/definitions/endpoints.CreateJobResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Create a job
       tags:
       - jobs
@@ -2202,19 +2208,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Delete a job
       tags:
       - jobs
@@ -2233,23 +2239,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.GetJobResponse'
+            $ref: '#/definitions/endpoints.GetJobResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get job by ID
       tags:
       - jobs
@@ -2268,7 +2274,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/internal_server_endpoints.UpdateJobRequest'
+          $ref: '#/definitions/endpoints.UpdateJobRequest'
       produces:
       - application/json
       responses:
@@ -2279,15 +2285,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Update a job
       tags:
       - jobs
@@ -2306,26 +2312,26 @@ paths:
         in: body
         name: request
         schema:
-          $ref: '#/definitions/internal_server_endpoints.StartJobRequest'
+          $ref: '#/definitions/endpoints.StartJobRequest'
       produces:
       - application/json
       responses:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/internal_server_endpoints.StartJobResponse'
+            $ref: '#/definitions/endpoints.StartJobResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Start job for a book
       tags:
       - jobs
@@ -2348,19 +2354,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.JobStatusResponse'
+            $ref: '#/definitions/endpoints.JobStatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get job status for a book
       tags:
       - jobs
@@ -2380,19 +2386,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.DetailedJobStatusResponse'
+            $ref: '#/definitions/endpoints.DetailedJobStatusResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get detailed job status for a book
       tags:
       - jobs
@@ -2450,15 +2456,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.LLMCallsResponse'
+            $ref: '#/definitions/endpoints.LLMCallsResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List LLM calls
       tags:
       - llmcalls
@@ -2477,15 +2483,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.LLMCallResponse'
+            $ref: '#/definitions/endpoints.LLMCallResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get an LLM call
       tags:
       - llmcalls
@@ -2504,11 +2510,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.LLMCallCountsResponse'
+            $ref: '#/definitions/endpoints.LLMCallCountsResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get LLM call counts by prompt key
       tags:
       - llmcalls
@@ -2546,15 +2552,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ListMetricsResponse'
+            $ref: '#/definitions/endpoints.ListMetricsResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List metrics
       tags:
       - metrics
@@ -2592,15 +2598,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.MetricsCostResponse'
+            $ref: '#/definitions/endpoints.MetricsCostResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get cost breakdown
       tags:
       - metrics
@@ -2619,15 +2625,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.MetricsDetailedResponse'
+            $ref: '#/definitions/endpoints.MetricsDetailedResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get detailed metrics with percentiles
       tags:
       - metrics
@@ -2661,15 +2667,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.MetricsSummaryResponse'
+            $ref: '#/definitions/endpoints.MetricsSummaryResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get metrics summary
       tags:
       - metrics
@@ -2682,11 +2688,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.PromptsListResponse'
+            $ref: '#/definitions/endpoints.PromptsListResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List all prompts
       tags:
       - prompts
@@ -2705,15 +2711,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.PromptResponse'
+            $ref: '#/definitions/endpoints.PromptResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get a prompt
       tags:
       - prompts
@@ -2726,11 +2732,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.HealthResponse'
+            $ref: '#/definitions/endpoints.HealthResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.HealthResponse'
+            $ref: '#/definitions/endpoints.HealthResponse'
       summary: Readiness check
       tags:
       - health
@@ -2743,11 +2749,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.SettingsResponse'
+            $ref: '#/definitions/endpoints.SettingsResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List all settings
       tags:
       - settings
@@ -2766,15 +2772,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.SettingResponse'
+            $ref: '#/definitions/endpoints.SettingResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get a setting
       tags:
       - settings
@@ -2793,22 +2799,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_server_endpoints.UpdateSettingRequest'
+          $ref: '#/definitions/endpoints.UpdateSettingRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.SettingResponse'
+            $ref: '#/definitions/endpoints.SettingResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Update a setting
       tags:
       - settings
@@ -2827,19 +2833,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.SettingResponse'
+            $ref: '#/definitions/endpoints.SettingResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Reset a setting to default
       tags:
       - settings
@@ -2852,7 +2858,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.StatusResponse'
+            $ref: '#/definitions/endpoints.StatusResponse'
       summary: Server status
       tags:
       - health
@@ -2865,15 +2871,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.TTSConfigResponse'
+            $ref: '#/definitions/endpoints.TTSConfigResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "503":
           description: Service Unavailable
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Get TTS configuration
       tags:
       - tts
@@ -2886,11 +2892,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ListVoicesResponse'
+            $ref: '#/definitions/endpoints.ListVoicesResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: List TTS voices
       tags:
       - voices
@@ -2904,22 +2910,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/internal_server_endpoints.CreateVoiceRequest'
+          $ref: '#/definitions/endpoints.CreateVoiceRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/internal_server_endpoints.VoiceResponse'
+            $ref: '#/definitions/endpoints.VoiceResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Create voice
       tags:
       - voices
@@ -2944,11 +2950,11 @@ paths:
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Delete voice
       tags:
       - voices
@@ -2973,15 +2979,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Set default voice
       tags:
       - voices
@@ -2994,11 +3000,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/internal_server_endpoints.SyncVoicesResponse'
+            $ref: '#/definitions/endpoints.SyncVoicesResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/internal_server_endpoints.ErrorResponse'
+            $ref: '#/definitions/endpoints.ErrorResponse'
       summary: Sync TTS voices
       tags:
       - voices

--- a/internal/jobs/common/load.go
+++ b/internal/jobs/common/load.go
@@ -315,6 +315,8 @@ func LoadPageStates(ctx context.Context, book *BookState) error {
 			extract_complete
 			ocr_complete
 			ocr_markdown
+			header
+			footer
 			headings
 			ocr_results {
 				provider
@@ -374,6 +376,12 @@ func LoadPageStates(ctx context.Context, book *BookState) error {
 		book.trackCIDLocked("Page", docID, cid)
 		if extractComplete, ok := page["extract_complete"].(bool); ok {
 			state.SetExtractDone(extractComplete)
+		}
+		if header, ok := page["header"].(string); ok {
+			state.SetHeader(header)
+		}
+		if footer, ok := page["footer"].(string); ok {
+			state.SetFooter(footer)
 		}
 
 		// Load OCR results from the relationship
@@ -955,6 +963,9 @@ func LoadStructureChapters(ctx context.Context, book *BookState) error {
 			toc_entry_id
 			matter_type
 			classification_reasoning
+			content_type
+			audio_include
+			audio_include_reasoning
 			mechanical_text
 			polished_text
 			word_count
@@ -1039,6 +1050,15 @@ func LoadStructureChapters(ctx context.Context, book *BookState) error {
 		if reasoning, ok := data["classification_reasoning"].(string); ok {
 			chapter.ClassifyReasoning = reasoning
 		}
+		if contentType, ok := data["content_type"].(string); ok {
+			chapter.ContentType = contentType
+		}
+		if include, ok := data["audio_include"].(bool); ok {
+			chapter.AudioInclude = include
+		}
+		if reasoning, ok := data["audio_include_reasoning"].(string); ok {
+			chapter.AudioIncludeReasoning = reasoning
+		}
 		if mechText, ok := data["mechanical_text"].(string); ok {
 			chapter.MechanicalText = mechText
 		}
@@ -1094,7 +1114,9 @@ func LoadStructureChapters(ctx context.Context, book *BookState) error {
 		if ch.MatterType != "" {
 			classifications[ch.EntryID] = ch.MatterType
 		}
-		if ch.ClassifyReasoning != "" {
+		if ch.AudioIncludeReasoning != "" {
+			reasonings[ch.EntryID] = ch.AudioIncludeReasoning
+		} else if ch.ClassifyReasoning != "" {
 			reasonings[ch.EntryID] = ch.ClassifyReasoning
 		}
 	}

--- a/internal/jobs/common/load.go
+++ b/internal/jobs/common/load.go
@@ -1055,6 +1055,14 @@ func LoadStructureChapters(ctx context.Context, book *BookState) error {
 		}
 		if include, ok := data["audio_include"].(bool); ok {
 			chapter.AudioInclude = include
+		} else if chapter.MatterType != "" {
+			// Backwards compat for older books without audio_include persisted.
+			switch chapter.MatterType {
+			case "back_matter":
+				chapter.AudioInclude = false
+			default:
+				chapter.AudioInclude = true
+			}
 		}
 		if reasoning, ok := data["audio_include_reasoning"].(string); ok {
 			chapter.AudioIncludeReasoning = reasoning

--- a/internal/jobs/common/ocr.go
+++ b/internal/jobs/common/ocr.go
@@ -84,9 +84,11 @@ func PersistOCRResult(ctx context.Context, book *BookState, state *PageState, oc
 			update := map[string]any{}
 			if result.Header != "" {
 				update["header"] = result.Header
+				state.SetHeader(result.Header)
 			}
 			if result.Footer != "" {
 				update["footer"] = result.Footer
+				state.SetFooter(result.Footer)
 			}
 			if writeResult, err := SendTracked(ctx, book, defra.WriteOp{
 				Collection: "Page",

--- a/internal/jobs/common/op_registry.go
+++ b/internal/jobs/common/op_registry.go
@@ -156,6 +156,7 @@ var OpRegistry = map[OpType]*OpConfig{
 			book.structurePolishFailed = 0
 			book.structureChapters = nil
 			book.structureClassifications = nil
+			book.structureClassifyReasonings = nil
 			book.structureClassifyPending = false
 		},
 		ResetHook: resetStructureHook,

--- a/internal/jobs/common/structure_helpers_test.go
+++ b/internal/jobs/common/structure_helpers_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildClassifyPromptIncludesContext(t *testing.T) {
+	chapter := &ChapterState{
+		EntryID:        "ch-1",
+		Title:          "Preface",
+		StartPage:      1,
+		EndPage:        2,
+		Level:          1,
+		LevelName:      "Chapter",
+		WordCount:      123,
+		MechanicalText: "This is some sample text for the preface section.",
+	}
+
+	prompt := BuildClassifyPrompt([]*ChapterState{chapter}, 200)
+
+	if !strings.Contains(prompt, "Total pages in book: 200") {
+		t.Fatalf("prompt missing total pages: %s", prompt)
+	}
+	if !strings.Contains(prompt, "level 1 Chapter, word_count 123") {
+		t.Fatalf("prompt missing level/word_count: %s", prompt)
+	}
+	if !strings.Contains(prompt, "[id: ch-1]") {
+		t.Fatalf("prompt missing entry id: %s", prompt)
+	}
+	if !strings.Contains(prompt, "text: This is some sample text") {
+		t.Fatalf("prompt missing text snippet: %s", prompt)
+	}
+}
+
+func TestClassifyResultUnmarshal(t *testing.T) {
+	payload := []byte(`{
+		"classifications": {"ch1": "front_matter"},
+		"content_types": {"ch1": "preface"},
+		"audio_include": {"ch1": true},
+		"reasoning": {"ch1": "Preface should be read aloud."}
+	}`)
+
+	var result ClassifyResult
+	if err := json.Unmarshal(payload, &result); err != nil {
+		t.Fatalf("failed to unmarshal classify result: %v", err)
+	}
+	if result.Classifications["ch1"] != "front_matter" {
+		t.Fatalf("classifications mismatch: %v", result.Classifications)
+	}
+	if result.ContentTypes["ch1"] != "preface" {
+		t.Fatalf("content_types mismatch: %v", result.ContentTypes)
+	}
+	if !result.AudioInclude["ch1"] {
+		t.Fatalf("audio_include mismatch: %v", result.AudioInclude)
+	}
+	if result.Reasoning["ch1"] == "" {
+		t.Fatalf("reasoning missing: %v", result.Reasoning)
+	}
+}
+
+func TestStripHeaderFooter(t *testing.T) {
+	text := "My Header\nLine one\nLine two\nPage Footer"
+	cleaned := StripHeaderFooter(text, "my header", "page footer")
+
+	if strings.Contains(cleaned, "My Header") {
+		t.Fatalf("header not stripped: %s", cleaned)
+	}
+	if strings.Contains(cleaned, "Page Footer") {
+		t.Fatalf("footer not stripped: %s", cleaned)
+	}
+	if !strings.Contains(cleaned, "Line one") || !strings.Contains(cleaned, "Line two") {
+		t.Fatalf("content missing after strip: %s", cleaned)
+	}
+}

--- a/internal/jobs/process_book/job/structure.go
+++ b/internal/jobs/process_book/job/structure.go
@@ -663,6 +663,7 @@ func (j *Job) createStructurePolishWorkUnits(ctx context.Context) []jobs.WorkUni
 		if !chapter.AudioInclude {
 			chapter.PolishedText = chapter.MechanicalText
 			chapter.PolishDone = true
+			j.Book.IncrementStructurePolished()
 			continue
 		}
 

--- a/internal/jobs/process_book/job/structure.go
+++ b/internal/jobs/process_book/job/structure.go
@@ -335,10 +335,14 @@ func (j *Job) extractChapterPages(startPage, endPage int) []common.PageText {
 			continue
 		}
 
+		header := pageState.GetHeader()
+		footer := pageState.GetFooter()
+		stripped := common.StripHeaderFooter(ocrText, header, footer)
+
 		pageTexts = append(pageTexts, common.PageText{
 			ScanPage:    pageNum,
 			RawText:     ocrText,
-			CleanedText: common.CleanPageText(ocrText),
+			CleanedText: common.CleanPageText(stripped),
 		})
 	}
 
@@ -424,7 +428,7 @@ func (j *Job) createStructureClassifyWorkUnit(ctx context.Context) (*jobs.WorkUn
 	}
 
 	chapters := j.Book.GetStructureChapters()
-	userPrompt := common.BuildClassifyPrompt(chapters)
+	userPrompt := common.BuildClassifyPrompt(chapters, j.Book.TotalPages)
 
 	schemaBytes, err := json.Marshal(common.ClassifyJSONSchema())
 	if err != nil {
@@ -552,8 +556,15 @@ func (j *Job) processStructureClassifyResult(ctx context.Context, result jobs.Wo
 		if matterType, ok := classifications[chapter.EntryID]; ok {
 			chapter.MatterType = matterType
 		}
+		if contentType, ok := classifyResult.ContentTypes[chapter.EntryID]; ok {
+			chapter.ContentType = contentType
+		}
+		if include, ok := classifyResult.AudioInclude[chapter.EntryID]; ok {
+			chapter.AudioInclude = include
+		}
 		if reasoning, ok := reasonings[chapter.EntryID]; ok {
 			chapter.ClassifyReasoning = reasoning
+			chapter.AudioIncludeReasoning = reasoning
 		}
 	}
 
@@ -580,10 +591,15 @@ func (j *Job) persistClassifyResults(ctx context.Context) error {
 		}
 
 		doc := map[string]any{
-			"matter_type": chapter.MatterType,
+			"matter_type":   chapter.MatterType,
+			"content_type":  chapter.ContentType,
+			"audio_include": chapter.AudioInclude,
 		}
 		if chapter.ClassifyReasoning != "" {
 			doc["classification_reasoning"] = chapter.ClassifyReasoning
+		}
+		if chapter.AudioIncludeReasoning != "" {
+			doc["audio_include_reasoning"] = chapter.AudioIncludeReasoning
 		}
 
 		if _, err := common.SendTracked(ctx, j.Book, defra.WriteOp{
@@ -642,6 +658,11 @@ func (j *Job) createStructurePolishWorkUnits(ctx context.Context) []jobs.WorkUni
 
 	for _, chapter := range chapters {
 		if chapter.PolishDone || chapter.MechanicalText == "" {
+			continue
+		}
+		if !chapter.AudioInclude {
+			chapter.PolishedText = chapter.MechanicalText
+			chapter.PolishDone = true
 			continue
 		}
 

--- a/internal/jobs/tts_generate/tts_generate.go
+++ b/internal/jobs/tts_generate/tts_generate.go
@@ -147,6 +147,7 @@ func loadChapters(ctx context.Context, client *defra.Client, bookID string) ([]*
 			level_name
 			entry_number
 			matter_type
+			audio_include
 			polished_text
 			sort_order
 			polish_complete
@@ -180,6 +181,9 @@ func loadChapters(ctx context.Context, client *defra.Client, bookID string) ([]*
 		if polishedText == "" {
 			continue
 		}
+		if !resolveAudioInclude(chData) {
+			continue
+		}
 
 		chapter := &Chapter{
 			DocID:        getString(chData, "_docID"),
@@ -204,6 +208,21 @@ func loadChapters(ctx context.Context, client *defra.Client, bookID string) ([]*
 	}
 
 	return chapters, nil
+}
+
+func resolveAudioInclude(chData map[string]any) bool {
+	if include, ok := chData["audio_include"].(bool); ok {
+		return include
+	}
+
+	switch getString(chData, "matter_type") {
+	case "back_matter":
+		return false
+	case "front_matter", "body":
+		return true
+	default:
+		return true
+	}
 }
 
 // loadBookAudio loads existing BookAudio record if present.

--- a/internal/jobs/tts_generate/tts_generate_test.go
+++ b/internal/jobs/tts_generate/tts_generate_test.go
@@ -1,0 +1,24 @@
+package tts_generate
+
+import "testing"
+
+func TestResolveAudioInclude(t *testing.T) {
+	if !resolveAudioInclude(map[string]any{"audio_include": true}) {
+		t.Fatal("expected audio_include=true to include")
+	}
+	if resolveAudioInclude(map[string]any{"audio_include": false}) {
+		t.Fatal("expected audio_include=false to exclude")
+	}
+	if !resolveAudioInclude(map[string]any{"matter_type": "front_matter"}) {
+		t.Fatal("expected front_matter to include by default")
+	}
+	if !resolveAudioInclude(map[string]any{"matter_type": "body"}) {
+		t.Fatal("expected body to include by default")
+	}
+	if resolveAudioInclude(map[string]any{"matter_type": "back_matter"}) {
+		t.Fatal("expected back_matter to exclude by default")
+	}
+	if !resolveAudioInclude(map[string]any{"matter_type": ""}) {
+		t.Fatal("expected unknown matter_type to include by default")
+	}
+}

--- a/internal/schema/schemas/chapter.graphql
+++ b/internal/schema/schemas/chapter.graphql
@@ -29,6 +29,11 @@ type Chapter {
     matter_type: String
     classification_reasoning: String
 
+    # Content classification (granular, for audiobook inclusion)
+    content_type: String
+    audio_include: Boolean
+    audio_include_reasoning: String
+
     # Hierarchy
     parent_id: String
 

--- a/internal/server/endpoints/books_chapters.go
+++ b/internal/server/endpoints/books_chapters.go
@@ -23,6 +23,9 @@ type Chapter struct {
 	EndPage                 int    `json:"end_page"`
 	MatterType              string `json:"matter_type"`
 	ClassificationReasoning string `json:"classification_reasoning,omitempty"`
+	ContentType             string `json:"content_type,omitempty"`
+	AudioInclude            bool   `json:"audio_include"`
+	AudioIncludeReasoning   string `json:"audio_include_reasoning,omitempty"`
 	SortOrder               int    `json:"sort_order"`
 	WordCount               int    `json:"word_count,omitempty"`
 	PageCount               int    `json:"page_count"`
@@ -144,6 +147,9 @@ func (e *GetBookChaptersEndpoint) handler(w http.ResponseWriter, r *http.Request
 			end_page
 			matter_type
 			classification_reasoning
+			content_type
+			audio_include
+			audio_include_reasoning
 			sort_order
 			word_count
 			polish_complete
@@ -184,6 +190,9 @@ func (e *GetBookChaptersEndpoint) handler(w http.ResponseWriter, r *http.Request
 				EndPage:                 endPage,
 				MatterType:              getString(cm, "matter_type"),
 				ClassificationReasoning: getString(cm, "classification_reasoning"),
+				ContentType:             getString(cm, "content_type"),
+				AudioInclude:            getBool(cm, "audio_include"),
+				AudioIncludeReasoning:   getString(cm, "audio_include_reasoning"),
 				SortOrder:               getInt(cm, "sort_order"),
 				WordCount:               getInt(cm, "word_count"),
 				PageCount:               endPage - startPage + 1,

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -33,7 +33,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.AgentLogDetailResponse"];
+                        "application/json": components["schemas"]["endpoints.AgentLogDetailResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -42,7 +42,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -51,7 +51,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -60,7 +60,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -69,7 +69,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -108,7 +108,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ListBooksResponse"];
+                        "application/json": components["schemas"]["endpoints.ListBooksResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -117,7 +117,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -126,7 +126,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -162,7 +162,7 @@ export interface paths {
             /** @description Ingest request */
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.IngestRequest"];
+                    "application/json": components["schemas"]["endpoints.IngestRequest"];
                 };
             };
             responses: {
@@ -172,7 +172,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.IngestResponse"];
+                        "application/json": components["schemas"]["endpoints.IngestResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -181,7 +181,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -190,7 +190,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -199,7 +199,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -254,7 +254,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.IngestResponse"];
+                        "application/json": components["schemas"]["endpoints.IngestResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -263,7 +263,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -272,7 +272,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -281,7 +281,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -328,7 +328,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.AgentLogsListResponse"];
+                        "application/json": components["schemas"]["endpoints.AgentLogsListResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -337,7 +337,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -346,7 +346,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -355,7 +355,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -397,7 +397,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.AudioStatusResponse"];
+                        "application/json": components["schemas"]["endpoints.AudioStatusResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -406,7 +406,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -415,7 +415,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -424,7 +424,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -477,7 +477,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "audio/mpeg": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "audio/mpeg": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -486,7 +486,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "audio/mpeg": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "audio/mpeg": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -530,7 +530,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.EpubExportResponse"];
+                        "application/json": components["schemas"]["endpoints.EpubExportResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -539,7 +539,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -548,7 +548,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -557,7 +557,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -606,7 +606,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/epub+zip": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/epub+zip": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -615,7 +615,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/epub+zip": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/epub+zip": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -659,7 +659,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.StorytellerExportResponse"];
+                        "application/json": components["schemas"]["endpoints.StorytellerExportResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -668,7 +668,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -677,7 +677,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -686,7 +686,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -735,7 +735,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/epub+zip": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/epub+zip": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -744,7 +744,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/epub+zip": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/epub+zip": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -783,7 +783,7 @@ export interface paths {
             /** @description TTS options */
             requestBody?: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.GenerateAudioRequest"];
+                    "application/json": components["schemas"]["endpoints.GenerateAudioRequest"];
                 };
             };
             responses: {
@@ -793,7 +793,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.GenerateAudioResponse"];
+                        "application/json": components["schemas"]["endpoints.GenerateAudioResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -802,7 +802,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -811,7 +811,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -820,7 +820,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -829,7 +829,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -869,7 +869,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ListPagesResponse"];
+                        "application/json": components["schemas"]["endpoints.ListPagesResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -878,7 +878,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -887,7 +887,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -896,7 +896,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -940,7 +940,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.GetPageResponse"];
+                        "application/json": components["schemas"]["endpoints.GetPageResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -949,7 +949,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -958,7 +958,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -967,7 +967,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -976,7 +976,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1029,7 +1029,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "image/png": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "image/png": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1038,7 +1038,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "image/png": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "image/png": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1047,7 +1047,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "image/png": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "image/png": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1091,7 +1091,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.RerunTocResponse"];
+                        "application/json": components["schemas"]["endpoints.RerunTocResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1100,7 +1100,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1109,7 +1109,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not enough pages have OCR complete */
@@ -1118,7 +1118,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1127,7 +1127,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1136,7 +1136,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1176,7 +1176,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.Book"];
+                        "application/json": components["schemas"]["endpoints.Book"];
                     };
                 };
                 /** @description Bad Request */
@@ -1185,7 +1185,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1194,7 +1194,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1203,7 +1203,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1212,7 +1212,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1259,7 +1259,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ChaptersResponse"];
+                        "application/json": components["schemas"]["endpoints.ChaptersResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1268,7 +1268,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1277,7 +1277,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1286,7 +1286,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1331,7 +1331,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.MetricsCostResponse"];
+                        "application/json": components["schemas"]["endpoints.MetricsCostResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1340,7 +1340,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1349,7 +1349,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1358,7 +1358,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1400,7 +1400,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.MetricsDetailedResponse"];
+                        "application/json": components["schemas"]["endpoints.MetricsDetailedResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1409,7 +1409,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1418,7 +1418,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1427,7 +1427,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1469,7 +1469,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.BookPromptsListResponse"];
+                        "application/json": components["schemas"]["endpoints.BookPromptsListResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1478,7 +1478,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1522,7 +1522,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.BookPromptResponse"];
+                        "application/json": components["schemas"]["endpoints.BookPromptResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1531,7 +1531,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1540,7 +1540,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1564,7 +1564,7 @@ export interface paths {
             /** @description Prompt override */
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.SetPromptRequest"];
+                    "application/json": components["schemas"]["endpoints.SetPromptRequest"];
                 };
             };
             responses: {
@@ -1574,7 +1574,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.BookPromptResponse"];
+                        "application/json": components["schemas"]["endpoints.BookPromptResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1583,7 +1583,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1592,7 +1592,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1622,7 +1622,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.BookPromptResponse"];
+                        "application/json": components["schemas"]["endpoints.BookPromptResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1631,7 +1631,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1640,7 +1640,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1676,7 +1676,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.HealthResponse"];
+                        "application/json": components["schemas"]["endpoints.HealthResponse"];
                     };
                 };
             };
@@ -1722,7 +1722,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ListJobsResponse"];
+                        "application/json": components["schemas"]["endpoints.ListJobsResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1731,7 +1731,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1740,7 +1740,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1760,7 +1760,7 @@ export interface paths {
             /** @description Job creation request */
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.CreateJobRequest"];
+                    "application/json": components["schemas"]["endpoints.CreateJobRequest"];
                 };
             };
             responses: {
@@ -1770,7 +1770,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.CreateJobResponse"];
+                        "application/json": components["schemas"]["endpoints.CreateJobResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1779,7 +1779,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1788,7 +1788,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1797,7 +1797,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1834,7 +1834,7 @@ export interface paths {
             /** @description Optional job type */
             requestBody?: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.StartJobRequest"];
+                    "application/json": components["schemas"]["endpoints.StartJobRequest"];
                 };
             };
             responses: {
@@ -1844,7 +1844,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.StartJobResponse"];
+                        "application/json": components["schemas"]["endpoints.StartJobResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1853,7 +1853,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1862,7 +1862,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1871,7 +1871,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1914,7 +1914,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.JobStatusResponse"];
+                        "application/json": components["schemas"]["endpoints.JobStatusResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1923,7 +1923,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -1932,7 +1932,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -1941,7 +1941,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -1983,7 +1983,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.DetailedJobStatusResponse"];
+                        "application/json": components["schemas"]["endpoints.DetailedJobStatusResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -1992,7 +1992,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2001,7 +2001,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2010,7 +2010,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2052,7 +2052,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.GetJobResponse"];
+                        "application/json": components["schemas"]["endpoints.GetJobResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -2061,7 +2061,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -2070,7 +2070,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2079,7 +2079,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2088,7 +2088,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2124,7 +2124,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "*/*": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "*/*": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -2133,7 +2133,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "*/*": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "*/*": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2142,7 +2142,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "*/*": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "*/*": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2151,7 +2151,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "*/*": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "*/*": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2175,7 +2175,7 @@ export interface paths {
             /** @description Update request */
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.UpdateJobRequest"];
+                    "application/json": components["schemas"]["endpoints.UpdateJobRequest"];
                 };
             };
             responses: {
@@ -2194,7 +2194,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2203,7 +2203,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2212,7 +2212,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2268,7 +2268,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.LLMCallsResponse"];
+                        "application/json": components["schemas"]["endpoints.LLMCallsResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -2277,7 +2277,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2286,7 +2286,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2328,7 +2328,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.LLMCallCountsResponse"];
+                        "application/json": components["schemas"]["endpoints.LLMCallCountsResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2337,7 +2337,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2379,7 +2379,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.LLMCallResponse"];
+                        "application/json": components["schemas"]["endpoints.LLMCallResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -2388,7 +2388,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2397,7 +2397,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2449,7 +2449,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ListMetricsResponse"];
+                        "application/json": components["schemas"]["endpoints.ListMetricsResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2458,7 +2458,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2467,7 +2467,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2519,7 +2519,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.MetricsCostResponse"];
+                        "application/json": components["schemas"]["endpoints.MetricsCostResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2528,7 +2528,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2537,7 +2537,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2579,7 +2579,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.MetricsDetailedResponse"];
+                        "application/json": components["schemas"]["endpoints.MetricsDetailedResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2588,7 +2588,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2597,7 +2597,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2647,7 +2647,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.MetricsSummaryResponse"];
+                        "application/json": components["schemas"]["endpoints.MetricsSummaryResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2656,7 +2656,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2665,7 +2665,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2704,7 +2704,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.PromptsListResponse"];
+                        "application/json": components["schemas"]["endpoints.PromptsListResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2713,7 +2713,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2755,7 +2755,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.PromptResponse"];
+                        "application/json": components["schemas"]["endpoints.PromptResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -2764,7 +2764,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2773,7 +2773,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2812,7 +2812,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.HealthResponse"];
+                        "application/json": components["schemas"]["endpoints.HealthResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -2821,7 +2821,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.HealthResponse"];
+                        "application/json": components["schemas"]["endpoints.HealthResponse"];
                     };
                 };
             };
@@ -2860,7 +2860,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.SettingsResponse"];
+                        "application/json": components["schemas"]["endpoints.SettingsResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2869,7 +2869,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2913,7 +2913,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.SettingResponse"];
+                        "application/json": components["schemas"]["endpoints.SettingResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -2922,7 +2922,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -2931,7 +2931,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2940,7 +2940,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -2980,7 +2980,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.SettingResponse"];
+                        "application/json": components["schemas"]["endpoints.SettingResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -2989,7 +2989,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -2998,7 +2998,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3020,7 +3020,7 @@ export interface paths {
             /** @description New value */
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.UpdateSettingRequest"];
+                    "application/json": components["schemas"]["endpoints.UpdateSettingRequest"];
                 };
             };
             responses: {
@@ -3030,7 +3030,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.SettingResponse"];
+                        "application/json": components["schemas"]["endpoints.SettingResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -3039,7 +3039,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3048,7 +3048,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3086,7 +3086,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.StatusResponse"];
+                        "application/json": components["schemas"]["endpoints.StatusResponse"];
                     };
                 };
             };
@@ -3125,7 +3125,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.TTSConfigResponse"];
+                        "application/json": components["schemas"]["endpoints.TTSConfigResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3134,7 +3134,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Service Unavailable */
@@ -3143,7 +3143,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3182,7 +3182,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ListVoicesResponse"];
+                        "application/json": components["schemas"]["endpoints.ListVoicesResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3191,7 +3191,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3211,7 +3211,7 @@ export interface paths {
             /** @description Voice details */
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["internal_server_endpoints.CreateVoiceRequest"];
+                    "application/json": components["schemas"]["endpoints.CreateVoiceRequest"];
                 };
             };
             responses: {
@@ -3221,7 +3221,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.VoiceResponse"];
+                        "application/json": components["schemas"]["endpoints.VoiceResponse"];
                     };
                 };
                 /** @description Bad Request */
@@ -3230,7 +3230,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3239,7 +3239,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3278,7 +3278,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.SyncVoicesResponse"];
+                        "application/json": components["schemas"]["endpoints.SyncVoicesResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3287,7 +3287,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3341,7 +3341,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3350,7 +3350,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3401,7 +3401,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -3410,7 +3410,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
                 /** @description Internal Server Error */
@@ -3419,7 +3419,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["internal_server_endpoints.ErrorResponse"];
+                        "application/json": components["schemas"]["endpoints.ErrorResponse"];
                     };
                 };
             };
@@ -3435,6 +3435,544 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        "endpoints.AgentLogDetailResponse": {
+            agent_type?: string;
+            book_id?: string;
+            completed_at?: string;
+            error?: string;
+            id?: string;
+            iterations?: number;
+            job_id?: string;
+            /** @description Detailed data */
+            messages?: number[];
+            result?: number[];
+            started_at?: string;
+            success?: boolean;
+            tool_calls?: number[];
+        };
+        "endpoints.AgentLogSummary": {
+            agent_type?: string;
+            completed_at?: string;
+            error?: string;
+            id?: string;
+            iterations?: number;
+            started_at?: string;
+            success?: boolean;
+        };
+        "endpoints.AgentLogSummaryResponse": {
+            agent_type?: string;
+            book_id?: string;
+            completed_at?: string;
+            error?: string;
+            id?: string;
+            iterations?: number;
+            job_id?: string;
+            started_at?: string;
+            success?: boolean;
+        };
+        "endpoints.AgentLogsListResponse": {
+            logs?: components["schemas"]["endpoints.AgentLogSummaryResponse"][];
+        };
+        "endpoints.AudioStatusResponse": {
+            book_id?: string;
+            chapter_count?: number;
+            chapters?: components["schemas"]["endpoints.ChapterAudioStatus"][];
+            format?: string;
+            provider?: string;
+            segment_count?: number;
+            status?: string;
+            total_cost_usd?: number;
+            total_duration_ms?: number;
+            voice?: string;
+        };
+        "endpoints.Book": {
+            author?: string;
+            created_at?: string;
+            id?: string;
+            page_count?: number;
+            page_pattern_analysis_json?: string;
+            status?: string;
+            title?: string;
+        };
+        "endpoints.BookMetadata": {
+            author?: string;
+            authors?: string[];
+            description?: string;
+            isbn?: string;
+            language?: string;
+            lccn?: string;
+            publication_year?: number;
+            publisher?: string;
+            subjects?: string[];
+            title?: string;
+        };
+        "endpoints.BookPromptResponse": {
+            cid?: string;
+            is_override?: boolean;
+            key?: string;
+            text?: string;
+            variables?: string[];
+        };
+        "endpoints.BookPromptsListResponse": {
+            book_id?: string;
+            prompts?: components["schemas"]["endpoints.BookPromptResponse"][];
+        };
+        "endpoints.ChapterAudioStatus": {
+            audio_file?: string;
+            chapter_idx?: number;
+            cost_usd?: number;
+            download_url?: string;
+            duration_ms?: number;
+            segment_count?: number;
+            title?: string;
+        };
+        "endpoints.ChapterPage": {
+            ocr_markdown?: string;
+            page_num?: number;
+        };
+        "endpoints.ChapterParagraph": {
+            id?: string;
+            polished_text?: string;
+            raw_text?: string;
+            sort_order?: number;
+            start_page?: number;
+            word_count?: number;
+        };
+        "endpoints.ChapterWithText": {
+            audio_include?: boolean;
+            audio_include_reasoning?: string;
+            classification_reasoning?: string;
+            content_type?: string;
+            edits_applied_json?: string;
+            end_page?: number;
+            entry_id?: string;
+            entry_number?: string;
+            id?: string;
+            level?: number;
+            level_name?: string;
+            matter_type?: string;
+            page_count?: number;
+            pages?: components["schemas"]["endpoints.ChapterPage"][];
+            paragraphs?: components["schemas"]["endpoints.ChapterParagraph"][];
+            polish_complete?: boolean;
+            polish_failed?: boolean;
+            polished_text?: string;
+            sort_order?: number;
+            start_page?: number;
+            title?: string;
+            word_count?: number;
+        };
+        "endpoints.ChaptersResponse": {
+            book_id?: string;
+            book_title?: string;
+            chapters?: components["schemas"]["endpoints.ChapterWithText"][];
+            has_chapters?: boolean;
+            total_pages?: number;
+        };
+        "endpoints.CreateJobRequest": {
+            job_type?: string;
+            metadata?: {
+                [key: string]: unknown;
+            };
+        };
+        "endpoints.CreateJobResponse": {
+            id?: string;
+        };
+        "endpoints.CreateVoiceRequest": {
+            description?: string;
+            name?: string;
+            voice_id?: string;
+        };
+        "endpoints.DefraStatus": {
+            container?: string;
+            health?: string;
+            url?: string;
+        };
+        "endpoints.DetailedJobStatusResponse": {
+            /** @description Agent logs summary */
+            agent_logs?: components["schemas"]["endpoints.AgentLogSummary"][];
+            book_id?: string;
+            /** @description Metadata status */
+            metadata?: components["schemas"]["endpoints.MetadataStatus"];
+            /** @description Per-provider OCR progress */
+            ocr_progress?: {
+                [key: string]: components["schemas"]["endpoints.ProviderProgress"];
+            };
+            /** @description Stage progress with costs */
+            stages?: components["schemas"]["endpoints.StageProgress"];
+            /** @description Structure status (common-structure job) */
+            structure?: components["schemas"]["endpoints.StructureStatus"];
+            /** @description ToC status */
+            toc?: components["schemas"]["endpoints.ToCStatus"];
+            total_pages?: number;
+        };
+        "endpoints.DiscoveredPattern": {
+            heading_format?: string;
+            level?: number;
+            level_name?: string;
+            pattern_type?: string;
+            range_end?: string;
+            range_start?: string;
+            reasoning?: string;
+        };
+        "endpoints.EpubExportResponse": {
+            author?: string;
+            book_id?: string;
+            chapter_count?: number;
+            created_at?: string;
+            download_url?: string;
+            file_path?: string;
+            file_size?: number;
+            title?: string;
+        };
+        "endpoints.ErrorResponse": {
+            error?: string;
+        };
+        "endpoints.ExcludedRange": {
+            end_page?: number;
+            reason?: string;
+            start_page?: number;
+        };
+        "endpoints.GenerateAudioRequest": {
+            /** @description Optional: output format (mp3, wav) */
+            format?: string;
+            /** @description Optional: voice ID */
+            voice?: string;
+        };
+        "endpoints.GenerateAudioResponse": {
+            book_id?: string;
+            chapters?: number;
+            job_id?: string;
+            provider?: string;
+            status?: string;
+        };
+        "endpoints.GetJobResponse": {
+            _docID?: string;
+            book_id?: string;
+            completed_at?: string;
+            created_at?: string;
+            error?: string;
+            job_type?: string;
+            /** @description Live status fields (only populated for running jobs) */
+            live_status?: {
+                [key: string]: string;
+            };
+            metadata?: {
+                [key: string]: unknown;
+            };
+            pending_units?: number;
+            progress?: {
+                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"];
+            };
+            started_at?: string;
+            status?: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.Status"];
+            worker_status?: {
+                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"];
+            };
+        };
+        "endpoints.GetPageResponse": {
+            ocr_markdown?: string;
+            ocr_results?: components["schemas"]["endpoints.OcrResult"][];
+            page_num?: number;
+            status?: components["schemas"]["endpoints.PageStatus"];
+        };
+        "endpoints.HealthResponse": {
+            defra?: string;
+            status?: string;
+        };
+        "endpoints.IngestRequest": {
+            author?: string;
+            pdf_paths?: string[];
+            title?: string;
+        };
+        "endpoints.IngestResponse": {
+            author?: string;
+            book_id?: string;
+            job_id?: string;
+            process_job_id?: string;
+            status?: string;
+            title?: string;
+        };
+        "endpoints.JobStatusResponse": {
+            book_id?: string;
+            is_complete?: boolean;
+            job_type?: string;
+            metadata_complete?: boolean;
+            ocr_complete?: number;
+            toc_extracted?: boolean;
+            toc_found?: boolean;
+            total_pages?: number;
+        };
+        "endpoints.LLMCallCountsResponse": {
+            counts?: {
+                [key: string]: number;
+            };
+        };
+        "endpoints.LLMCallResponse": {
+            call?: components["schemas"]["github_com_jackzampolin_shelf_internal_llmcall.Call"];
+            error?: string;
+        };
+        "endpoints.LLMCallsResponse": {
+            calls?: components["schemas"]["github_com_jackzampolin_shelf_internal_llmcall.Call"][];
+            total?: number;
+        };
+        "endpoints.ListBooksResponse": {
+            books?: components["schemas"]["endpoints.Book"][];
+        };
+        "endpoints.ListJobsResponse": {
+            jobs?: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.Record"][];
+        };
+        "endpoints.ListMetricsResponse": {
+            count?: number;
+            metrics?: components["schemas"]["github_com_jackzampolin_shelf_internal_metrics.Metric"][];
+        };
+        "endpoints.ListPagesResponse": {
+            pages?: components["schemas"]["endpoints.PageSummary"][];
+            total_pages?: number;
+        };
+        "endpoints.ListVoicesResponse": {
+            voices?: components["schemas"]["endpoints.VoiceResponse"][];
+        };
+        "endpoints.MetadataStatus": {
+            complete?: boolean;
+            cost_usd?: number;
+            data?: components["schemas"]["endpoints.BookMetadata"];
+            failed?: boolean;
+            started?: boolean;
+        };
+        "endpoints.MetricsCostResponse": {
+            breakdown?: {
+                [key: string]: number;
+            };
+            total_cost_usd?: number;
+        };
+        "endpoints.MetricsDetailedResponse": {
+            book_id?: string;
+            stages?: {
+                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_metrics.DetailedStats"];
+            };
+        };
+        "endpoints.MetricsSummaryResponse": {
+            avg_cost_usd?: number;
+            avg_time_seconds?: number;
+            avg_tokens?: number;
+            count?: number;
+            error_count?: number;
+            success_count?: number;
+            total_cost_usd?: number;
+            total_time_seconds?: number;
+            total_tokens?: number;
+        };
+        "endpoints.OcrResult": {
+            confidence?: number;
+            provider?: string;
+            text?: string;
+        };
+        "endpoints.PageStatus": {
+            extract_complete?: boolean;
+            ocr_complete?: boolean;
+        };
+        "endpoints.PageSummary": {
+            ocr_complete?: boolean;
+            page_num?: number;
+        };
+        "endpoints.PatternAnalysisResult": {
+            excluded_ranges?: components["schemas"]["endpoints.ExcludedRange"][];
+            patterns?: components["schemas"]["endpoints.DiscoveredPattern"][];
+            reasoning?: string;
+        };
+        "endpoints.PromptResponse": {
+            description?: string;
+            doc_id?: string;
+            hash?: string;
+            key?: string;
+            text?: string;
+            variables?: string[];
+        };
+        "endpoints.PromptsListResponse": {
+            prompts?: components["schemas"]["endpoints.PromptResponse"][];
+        };
+        "endpoints.ProviderProgress": {
+            complete?: number;
+            cost_usd?: number;
+            total?: number;
+        };
+        "endpoints.ProvidersStatus": {
+            llm?: string[];
+            ocr?: string[];
+        };
+        "endpoints.RerunTocResponse": {
+            job_id?: string;
+            message?: string;
+        };
+        "endpoints.SetPromptRequest": {
+            note?: string;
+            text?: string;
+        };
+        "endpoints.SettingResponse": {
+            entry?: components["schemas"]["github_com_jackzampolin_shelf_internal_config.Entry"];
+            error?: string;
+        };
+        "endpoints.SettingsResponse": {
+            settings?: {
+                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_config.Entry"];
+            };
+        };
+        "endpoints.StageProgress": {
+            ocr?: {
+                complete?: number;
+                cost_by_provider?: {
+                    [key: string]: number;
+                };
+                total?: number;
+                total_cost_usd?: number;
+            };
+            pattern_analysis?: {
+                complete?: boolean;
+                cost_usd?: number;
+            };
+        };
+        "endpoints.StartJobRequest": {
+            /** @description Optional: force restart even if already complete */
+            force?: boolean;
+            /** @description Optional: defaults to "process-book" */
+            job_type?: string;
+            /** @description Optional: reset this operation and downstream deps before starting */
+            reset_from?: string;
+            /** @description Optional: pipeline variant (standard, photo-book, text-only, ocr-only) */
+            variant?: string;
+        };
+        "endpoints.StartJobResponse": {
+            book_id?: string;
+            job_id?: string;
+            job_type?: string;
+            status?: string;
+        };
+        "endpoints.StatusResponse": {
+            defra?: components["schemas"]["endpoints.DefraStatus"];
+            providers?: components["schemas"]["endpoints.ProvidersStatus"];
+            server?: string;
+        };
+        "endpoints.StorytellerExportResponse": {
+            audio_chapters?: number;
+            author?: string;
+            book_id?: string;
+            chapter_count?: number;
+            created_at?: string;
+            download_url?: string;
+            file_path?: string;
+            file_size?: number;
+            title?: string;
+            total_duration_ms?: number;
+        };
+        "endpoints.StructureStatus": {
+            chapter_count?: number;
+            chapters_extracted?: number;
+            chapters_polished?: number;
+            chapters_total?: number;
+            complete?: boolean;
+            cost_usd?: number;
+            failed?: boolean;
+            /** @description Phase tracking (build -> extract -> classify -> polish -> finalize) */
+            phase?: string;
+            polish_failed?: number;
+            retries?: number;
+            started?: boolean;
+        };
+        "endpoints.SyncVoicesResponse": {
+            message?: string;
+            synced?: number;
+        };
+        "endpoints.TTSConfigResponse": {
+            default_format?: string;
+            default_voice?: string;
+            formats?: string[];
+            model?: string;
+            provider?: string;
+            voice_cloning_url?: string;
+            voices?: components["schemas"]["endpoints.TTSVoice"][];
+        };
+        "endpoints.TTSVoice": {
+            description?: string;
+            name?: string;
+            voice_id?: string;
+        };
+        "endpoints.ToCEntry": {
+            actual_page_num?: number;
+            entry_number?: string;
+            is_linked?: boolean;
+            level?: number;
+            level_name?: string;
+            printed_page_number?: string;
+            sort_order?: number;
+            /** @description "extracted" or "discovered" */
+            source?: string;
+            title?: string;
+        };
+        "endpoints.ToCStatus": {
+            cost_usd?: number;
+            /** @description All entries discovered */
+            discover_complete?: boolean;
+            end_page?: number;
+            entries?: components["schemas"]["endpoints.ToCEntry"][];
+            /** @description Actually discovered (source="discovered") */
+            entries_discovered?: number;
+            entries_linked?: number;
+            /** @description From pattern analysis (how many should be discovered) */
+            entries_to_find?: number;
+            /** @description Entries (when extracted) */
+            entry_count?: number;
+            /** @description Number of excluded page ranges */
+            excluded_ranges?: number;
+            extract_complete?: boolean;
+            extract_failed?: boolean;
+            /** @description Extract stage */
+            extract_started?: boolean;
+            finalize_complete?: boolean;
+            finalize_failed?: boolean;
+            finalize_retries?: number;
+            /** @description Finalize stage (overall) */
+            finalize_started?: boolean;
+            finder_complete?: boolean;
+            finder_failed?: boolean;
+            /** @description Finder stage */
+            finder_started?: boolean;
+            found?: boolean;
+            link_complete?: boolean;
+            link_failed?: boolean;
+            link_retries?: number;
+            /** @description Link stage */
+            link_started?: boolean;
+            /** @description Full pattern analysis result */
+            pattern_analysis?: components["schemas"]["endpoints.PatternAnalysisResult"];
+            /** @description Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation */
+            pattern_complete?: boolean;
+            /** @description Number of patterns discovered */
+            patterns_found?: number;
+            start_page?: number;
+            /** @description Gap validation done (same as FinalizeComplete for now) */
+            validate_complete?: boolean;
+        };
+        "endpoints.UpdateJobRequest": {
+            error?: string;
+            metadata?: {
+                [key: string]: unknown;
+            };
+            status?: string;
+        };
+        "endpoints.UpdateSettingRequest": {
+            description?: string;
+            value?: unknown;
+        };
+        "endpoints.VoiceResponse": {
+            created_at?: string;
+            description?: string;
+            is_default?: boolean;
+            name?: string;
+            provider?: string;
+            synced_at?: string;
+            voice_id?: string;
+        };
         "github_com_jackzampolin_shelf_internal_config.Entry": {
             /** @description DefraDB document ID */
             _docID?: string;
@@ -3569,541 +4107,6 @@ export interface components {
             success?: boolean;
             total_seconds?: number;
             total_tokens?: number;
-        };
-        "internal_server_endpoints.AgentLogDetailResponse": {
-            agent_type?: string;
-            book_id?: string;
-            completed_at?: string;
-            error?: string;
-            id?: string;
-            iterations?: number;
-            job_id?: string;
-            /** @description Detailed data */
-            messages?: number[];
-            result?: number[];
-            started_at?: string;
-            success?: boolean;
-            tool_calls?: number[];
-        };
-        "internal_server_endpoints.AgentLogSummary": {
-            agent_type?: string;
-            completed_at?: string;
-            error?: string;
-            id?: string;
-            iterations?: number;
-            started_at?: string;
-            success?: boolean;
-        };
-        "internal_server_endpoints.AgentLogSummaryResponse": {
-            agent_type?: string;
-            book_id?: string;
-            completed_at?: string;
-            error?: string;
-            id?: string;
-            iterations?: number;
-            job_id?: string;
-            started_at?: string;
-            success?: boolean;
-        };
-        "internal_server_endpoints.AgentLogsListResponse": {
-            logs?: components["schemas"]["internal_server_endpoints.AgentLogSummaryResponse"][];
-        };
-        "internal_server_endpoints.AudioStatusResponse": {
-            book_id?: string;
-            chapter_count?: number;
-            chapters?: components["schemas"]["internal_server_endpoints.ChapterAudioStatus"][];
-            format?: string;
-            provider?: string;
-            segment_count?: number;
-            status?: string;
-            total_cost_usd?: number;
-            total_duration_ms?: number;
-            voice?: string;
-        };
-        "internal_server_endpoints.Book": {
-            author?: string;
-            created_at?: string;
-            id?: string;
-            page_count?: number;
-            page_pattern_analysis_json?: string;
-            status?: string;
-            title?: string;
-        };
-        "internal_server_endpoints.BookMetadata": {
-            author?: string;
-            authors?: string[];
-            description?: string;
-            isbn?: string;
-            language?: string;
-            lccn?: string;
-            publication_year?: number;
-            publisher?: string;
-            subjects?: string[];
-            title?: string;
-        };
-        "internal_server_endpoints.BookPromptResponse": {
-            cid?: string;
-            is_override?: boolean;
-            key?: string;
-            text?: string;
-            variables?: string[];
-        };
-        "internal_server_endpoints.BookPromptsListResponse": {
-            book_id?: string;
-            prompts?: components["schemas"]["internal_server_endpoints.BookPromptResponse"][];
-        };
-        "internal_server_endpoints.ChapterAudioStatus": {
-            audio_file?: string;
-            chapter_idx?: number;
-            cost_usd?: number;
-            download_url?: string;
-            duration_ms?: number;
-            segment_count?: number;
-            title?: string;
-        };
-        "internal_server_endpoints.ChapterPage": {
-            ocr_markdown?: string;
-            page_num?: number;
-        };
-        "internal_server_endpoints.ChapterParagraph": {
-            id?: string;
-            polished_text?: string;
-            raw_text?: string;
-            sort_order?: number;
-            start_page?: number;
-            word_count?: number;
-        };
-        "internal_server_endpoints.ChapterWithText": {
-            classification_reasoning?: string;
-            edits_applied_json?: string;
-            end_page?: number;
-            entry_id?: string;
-            entry_number?: string;
-            id?: string;
-            level?: number;
-            level_name?: string;
-            matter_type?: string;
-            page_count?: number;
-            pages?: components["schemas"]["internal_server_endpoints.ChapterPage"][];
-            paragraphs?: components["schemas"]["internal_server_endpoints.ChapterParagraph"][];
-            polish_complete?: boolean;
-            polish_failed?: boolean;
-            polished_text?: string;
-            sort_order?: number;
-            start_page?: number;
-            title?: string;
-            word_count?: number;
-        };
-        "internal_server_endpoints.ChaptersResponse": {
-            book_id?: string;
-            book_title?: string;
-            chapters?: components["schemas"]["internal_server_endpoints.ChapterWithText"][];
-            has_chapters?: boolean;
-            total_pages?: number;
-        };
-        "internal_server_endpoints.CreateJobRequest": {
-            job_type?: string;
-            metadata?: {
-                [key: string]: unknown;
-            };
-        };
-        "internal_server_endpoints.CreateJobResponse": {
-            id?: string;
-        };
-        "internal_server_endpoints.CreateVoiceRequest": {
-            description?: string;
-            name?: string;
-            voice_id?: string;
-        };
-        "internal_server_endpoints.DefraStatus": {
-            container?: string;
-            health?: string;
-            url?: string;
-        };
-        "internal_server_endpoints.DetailedJobStatusResponse": {
-            /** @description Agent logs summary */
-            agent_logs?: components["schemas"]["internal_server_endpoints.AgentLogSummary"][];
-            book_id?: string;
-            /** @description Metadata status */
-            metadata?: components["schemas"]["internal_server_endpoints.MetadataStatus"];
-            /** @description Per-provider OCR progress */
-            ocr_progress?: {
-                [key: string]: components["schemas"]["internal_server_endpoints.ProviderProgress"];
-            };
-            /** @description Stage progress with costs */
-            stages?: components["schemas"]["internal_server_endpoints.StageProgress"];
-            /** @description Structure status (common-structure job) */
-            structure?: components["schemas"]["internal_server_endpoints.StructureStatus"];
-            /** @description ToC status */
-            toc?: components["schemas"]["internal_server_endpoints.ToCStatus"];
-            total_pages?: number;
-        };
-        "internal_server_endpoints.DiscoveredPattern": {
-            heading_format?: string;
-            level?: number;
-            level_name?: string;
-            pattern_type?: string;
-            range_end?: string;
-            range_start?: string;
-            reasoning?: string;
-        };
-        "internal_server_endpoints.EpubExportResponse": {
-            author?: string;
-            book_id?: string;
-            chapter_count?: number;
-            created_at?: string;
-            download_url?: string;
-            file_path?: string;
-            file_size?: number;
-            title?: string;
-        };
-        "internal_server_endpoints.ErrorResponse": {
-            error?: string;
-        };
-        "internal_server_endpoints.ExcludedRange": {
-            end_page?: number;
-            reason?: string;
-            start_page?: number;
-        };
-        "internal_server_endpoints.GenerateAudioRequest": {
-            /** @description Optional: output format (mp3, wav) */
-            format?: string;
-            /** @description Optional: voice ID */
-            voice?: string;
-        };
-        "internal_server_endpoints.GenerateAudioResponse": {
-            book_id?: string;
-            chapters?: number;
-            job_id?: string;
-            provider?: string;
-            status?: string;
-        };
-        "internal_server_endpoints.GetJobResponse": {
-            _docID?: string;
-            book_id?: string;
-            completed_at?: string;
-            created_at?: string;
-            error?: string;
-            job_type?: string;
-            /** @description Live status fields (only populated for running jobs) */
-            live_status?: {
-                [key: string]: string;
-            };
-            metadata?: {
-                [key: string]: unknown;
-            };
-            pending_units?: number;
-            progress?: {
-                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.ProviderProgress"];
-            };
-            started_at?: string;
-            status?: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.Status"];
-            worker_status?: {
-                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.WorkerStatusInfo"];
-            };
-        };
-        "internal_server_endpoints.GetPageResponse": {
-            ocr_markdown?: string;
-            ocr_results?: components["schemas"]["internal_server_endpoints.OcrResult"][];
-            page_num?: number;
-            status?: components["schemas"]["internal_server_endpoints.PageStatus"];
-        };
-        "internal_server_endpoints.HealthResponse": {
-            defra?: string;
-            status?: string;
-        };
-        "internal_server_endpoints.IngestRequest": {
-            author?: string;
-            pdf_paths?: string[];
-            title?: string;
-        };
-        "internal_server_endpoints.IngestResponse": {
-            author?: string;
-            book_id?: string;
-            job_id?: string;
-            process_job_id?: string;
-            status?: string;
-            title?: string;
-        };
-        "internal_server_endpoints.JobStatusResponse": {
-            book_id?: string;
-            is_complete?: boolean;
-            job_type?: string;
-            metadata_complete?: boolean;
-            ocr_complete?: number;
-            toc_extracted?: boolean;
-            toc_found?: boolean;
-            total_pages?: number;
-        };
-        "internal_server_endpoints.LLMCallCountsResponse": {
-            counts?: {
-                [key: string]: number;
-            };
-        };
-        "internal_server_endpoints.LLMCallResponse": {
-            call?: components["schemas"]["github_com_jackzampolin_shelf_internal_llmcall.Call"];
-            error?: string;
-        };
-        "internal_server_endpoints.LLMCallsResponse": {
-            calls?: components["schemas"]["github_com_jackzampolin_shelf_internal_llmcall.Call"][];
-            total?: number;
-        };
-        "internal_server_endpoints.ListBooksResponse": {
-            books?: components["schemas"]["internal_server_endpoints.Book"][];
-        };
-        "internal_server_endpoints.ListJobsResponse": {
-            jobs?: components["schemas"]["github_com_jackzampolin_shelf_internal_jobs.Record"][];
-        };
-        "internal_server_endpoints.ListMetricsResponse": {
-            count?: number;
-            metrics?: components["schemas"]["github_com_jackzampolin_shelf_internal_metrics.Metric"][];
-        };
-        "internal_server_endpoints.ListPagesResponse": {
-            pages?: components["schemas"]["internal_server_endpoints.PageSummary"][];
-            total_pages?: number;
-        };
-        "internal_server_endpoints.ListVoicesResponse": {
-            voices?: components["schemas"]["internal_server_endpoints.VoiceResponse"][];
-        };
-        "internal_server_endpoints.MetadataStatus": {
-            complete?: boolean;
-            cost_usd?: number;
-            data?: components["schemas"]["internal_server_endpoints.BookMetadata"];
-            failed?: boolean;
-            started?: boolean;
-        };
-        "internal_server_endpoints.MetricsCostResponse": {
-            breakdown?: {
-                [key: string]: number;
-            };
-            total_cost_usd?: number;
-        };
-        "internal_server_endpoints.MetricsDetailedResponse": {
-            book_id?: string;
-            stages?: {
-                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_metrics.DetailedStats"];
-            };
-        };
-        "internal_server_endpoints.MetricsSummaryResponse": {
-            avg_cost_usd?: number;
-            avg_time_seconds?: number;
-            avg_tokens?: number;
-            count?: number;
-            error_count?: number;
-            success_count?: number;
-            total_cost_usd?: number;
-            total_time_seconds?: number;
-            total_tokens?: number;
-        };
-        "internal_server_endpoints.OcrResult": {
-            confidence?: number;
-            provider?: string;
-            text?: string;
-        };
-        "internal_server_endpoints.PageStatus": {
-            extract_complete?: boolean;
-            ocr_complete?: boolean;
-        };
-        "internal_server_endpoints.PageSummary": {
-            ocr_complete?: boolean;
-            page_num?: number;
-        };
-        "internal_server_endpoints.PatternAnalysisResult": {
-            excluded_ranges?: components["schemas"]["internal_server_endpoints.ExcludedRange"][];
-            patterns?: components["schemas"]["internal_server_endpoints.DiscoveredPattern"][];
-            reasoning?: string;
-        };
-        "internal_server_endpoints.PromptResponse": {
-            description?: string;
-            doc_id?: string;
-            hash?: string;
-            key?: string;
-            text?: string;
-            variables?: string[];
-        };
-        "internal_server_endpoints.PromptsListResponse": {
-            prompts?: components["schemas"]["internal_server_endpoints.PromptResponse"][];
-        };
-        "internal_server_endpoints.ProviderProgress": {
-            complete?: number;
-            cost_usd?: number;
-            total?: number;
-        };
-        "internal_server_endpoints.ProvidersStatus": {
-            llm?: string[];
-            ocr?: string[];
-        };
-        "internal_server_endpoints.RerunTocResponse": {
-            job_id?: string;
-            message?: string;
-        };
-        "internal_server_endpoints.SetPromptRequest": {
-            note?: string;
-            text?: string;
-        };
-        "internal_server_endpoints.SettingResponse": {
-            entry?: components["schemas"]["github_com_jackzampolin_shelf_internal_config.Entry"];
-            error?: string;
-        };
-        "internal_server_endpoints.SettingsResponse": {
-            settings?: {
-                [key: string]: components["schemas"]["github_com_jackzampolin_shelf_internal_config.Entry"];
-            };
-        };
-        "internal_server_endpoints.StageProgress": {
-            ocr?: {
-                complete?: number;
-                cost_by_provider?: {
-                    [key: string]: number;
-                };
-                total?: number;
-                total_cost_usd?: number;
-            };
-            pattern_analysis?: {
-                complete?: boolean;
-                cost_usd?: number;
-            };
-        };
-        "internal_server_endpoints.StartJobRequest": {
-            /** @description Optional: force restart even if already complete */
-            force?: boolean;
-            /** @description Optional: defaults to "process-book" */
-            job_type?: string;
-            /** @description Optional: reset this operation and downstream deps before starting */
-            reset_from?: string;
-            /** @description Optional: pipeline variant (standard, photo-book, text-only, ocr-only) */
-            variant?: string;
-        };
-        "internal_server_endpoints.StartJobResponse": {
-            book_id?: string;
-            job_id?: string;
-            job_type?: string;
-            status?: string;
-        };
-        "internal_server_endpoints.StatusResponse": {
-            defra?: components["schemas"]["internal_server_endpoints.DefraStatus"];
-            providers?: components["schemas"]["internal_server_endpoints.ProvidersStatus"];
-            server?: string;
-        };
-        "internal_server_endpoints.StorytellerExportResponse": {
-            audio_chapters?: number;
-            author?: string;
-            book_id?: string;
-            chapter_count?: number;
-            created_at?: string;
-            download_url?: string;
-            file_path?: string;
-            file_size?: number;
-            title?: string;
-            total_duration_ms?: number;
-        };
-        "internal_server_endpoints.StructureStatus": {
-            chapter_count?: number;
-            chapters_extracted?: number;
-            chapters_polished?: number;
-            chapters_total?: number;
-            complete?: boolean;
-            cost_usd?: number;
-            failed?: boolean;
-            /** @description Phase tracking (build -> extract -> classify -> polish -> finalize) */
-            phase?: string;
-            polish_failed?: number;
-            retries?: number;
-            started?: boolean;
-        };
-        "internal_server_endpoints.SyncVoicesResponse": {
-            message?: string;
-            synced?: number;
-        };
-        "internal_server_endpoints.TTSConfigResponse": {
-            default_format?: string;
-            default_voice?: string;
-            formats?: string[];
-            model?: string;
-            provider?: string;
-            voice_cloning_url?: string;
-            voices?: components["schemas"]["internal_server_endpoints.TTSVoice"][];
-        };
-        "internal_server_endpoints.TTSVoice": {
-            description?: string;
-            name?: string;
-            voice_id?: string;
-        };
-        "internal_server_endpoints.ToCEntry": {
-            actual_page_num?: number;
-            entry_number?: string;
-            is_linked?: boolean;
-            level?: number;
-            level_name?: string;
-            printed_page_number?: string;
-            sort_order?: number;
-            /** @description "extracted" or "discovered" */
-            source?: string;
-            title?: string;
-        };
-        "internal_server_endpoints.ToCStatus": {
-            cost_usd?: number;
-            /** @description All entries discovered */
-            discover_complete?: boolean;
-            end_page?: number;
-            entries?: components["schemas"]["internal_server_endpoints.ToCEntry"][];
-            /** @description Actually discovered (source="discovered") */
-            entries_discovered?: number;
-            entries_linked?: number;
-            /** @description From pattern analysis (how many should be discovered) */
-            entries_to_find?: number;
-            /** @description Entries (when extracted) */
-            entry_count?: number;
-            /** @description Number of excluded page ranges */
-            excluded_ranges?: number;
-            extract_complete?: boolean;
-            extract_failed?: boolean;
-            /** @description Extract stage */
-            extract_started?: boolean;
-            finalize_complete?: boolean;
-            finalize_failed?: boolean;
-            finalize_retries?: number;
-            /** @description Finalize stage (overall) */
-            finalize_started?: boolean;
-            finder_complete?: boolean;
-            finder_failed?: boolean;
-            /** @description Finder stage */
-            finder_started?: boolean;
-            found?: boolean;
-            link_complete?: boolean;
-            link_failed?: boolean;
-            link_retries?: number;
-            /** @description Link stage */
-            link_started?: boolean;
-            /** @description Full pattern analysis result */
-            pattern_analysis?: components["schemas"]["internal_server_endpoints.PatternAnalysisResult"];
-            /** @description Finalize sub-phases: Pattern Analysis → Chapter Discovery → Gap Validation */
-            pattern_complete?: boolean;
-            /** @description Number of patterns discovered */
-            patterns_found?: number;
-            start_page?: number;
-            /** @description Gap validation done (same as FinalizeComplete for now) */
-            validate_complete?: boolean;
-        };
-        "internal_server_endpoints.UpdateJobRequest": {
-            error?: string;
-            metadata?: {
-                [key: string]: unknown;
-            };
-            status?: string;
-        };
-        "internal_server_endpoints.UpdateSettingRequest": {
-            description?: string;
-            value?: unknown;
-        };
-        "internal_server_endpoints.VoiceResponse": {
-            created_at?: string;
-            description?: string;
-            is_default?: boolean;
-            name?: string;
-            provider?: string;
-            synced_at?: string;
-            voice_id?: string;
         };
         /**
          * Format: int64

--- a/web/src/components/book/tabs/OverviewTab.tsx
+++ b/web/src/components/book/tabs/OverviewTab.tsx
@@ -19,6 +19,18 @@ export function OverviewTab({ bookId, book }: OverviewTabProps) {
   const bodyChapters = chapters.filter((c: { matter_type?: string }) => c.matter_type === 'body').length
   const backMatter = chapters.filter((c: { matter_type?: string }) => c.matter_type === 'back_matter').length
 
+  const resolveAudioInclude = (chapter: { audio_include?: boolean; matter_type?: string }) => {
+    if (typeof chapter.audio_include === 'boolean') {
+      return chapter.audio_include
+    }
+    return chapter.matter_type !== 'back_matter'
+  }
+
+  const audioIncluded = chapters.filter((c: { audio_include?: boolean; matter_type?: string }) =>
+    resolveAudioInclude(c)
+  ).length
+  const audioExcluded = chapters.length - audioIncluded
+
   // Determine processing stage
   const getProcessingStage = () => {
     if (!detailedStatus) return null
@@ -98,6 +110,15 @@ export function OverviewTab({ bookId, book }: OverviewTabProps) {
             <StructureStat label="Front Matter" count={frontMatter} color="purple" />
             <StructureStat label="Body" count={bodyChapters} color="blue" />
             <StructureStat label="Back Matter" count={backMatter} color="orange" />
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-gray-600">
+            <span className="font-medium text-gray-700">Audiobook:</span>
+            <span className="px-2 py-1 rounded-full bg-green-100 text-green-800">
+              {audioIncluded} included
+            </span>
+            <span className="px-2 py-1 rounded-full bg-gray-100 text-gray-700">
+              {audioExcluded} excluded
+            </span>
           </div>
           <div className="mt-4 pt-4 border-t">
             <Link

--- a/web/src/components/book/tabs/ReadTab.tsx
+++ b/web/src/components/book/tabs/ReadTab.tsx
@@ -16,6 +16,9 @@ interface Chapter {
   start_page: number
   end_page: number
   matter_type: string
+  content_type?: string
+  audio_include?: boolean
+  audio_include_reasoning?: string
   sort_order: number
   word_count?: number
   page_count: number
@@ -172,6 +175,7 @@ interface ChapterCardProps {
 function ChapterCard({ chapter, bookId, isExpanded, onToggle, matterColors }: ChapterCardProps) {
   const hasPolishedText = !!chapter.polished_text
   const indent = chapter.level * 16
+  const audioInclude = chapter.audio_include ?? false
 
   return (
     <div className="group">
@@ -219,7 +223,7 @@ function ChapterCard({ chapter, bookId, isExpanded, onToggle, matterColors }: Ch
           </div>
         </div>
 
-        {/* Right side: matter type badge and link */}
+        {/* Right side: classification badges and link */}
         <div className="flex items-center space-x-3 ml-4">
           <span
             className={`px-2 py-1 rounded text-xs font-medium border ${
@@ -227,6 +231,19 @@ function ChapterCard({ chapter, bookId, isExpanded, onToggle, matterColors }: Ch
             }`}
           >
             {chapter.matter_type?.replace('_', ' ') || 'unknown'}
+          </span>
+          {chapter.content_type && (
+            <span className="px-2 py-1 rounded text-xs font-medium border bg-gray-50 text-gray-700 border-gray-200">
+              {chapter.content_type.replace('_', ' ')}
+            </span>
+          )}
+          <span
+            className={`px-2 py-1 rounded text-xs font-medium border ${
+              audioInclude ? 'bg-green-100 text-green-800 border-green-200' : 'bg-gray-100 text-gray-600 border-gray-200'
+            }`}
+            title={chapter.audio_include_reasoning || ''}
+          >
+            {audioInclude ? 'Audio' : 'Excluded'}
           </span>
           <Link
             to="/books/$bookId/pages/$pageNum"


### PR DESCRIPTION
## Summary

Closes #179.

- **Granular content classification**: Expanded the structure classify phase from 3 categories (front_matter/body/back_matter) to 20 granular `content_type` values (preface, foreword, index, bibliography, appendix, etc.) with `audio_include` boolean and reasoning per chapter
- **TTS filtering**: TTS job now filters chapters by `audio_include`, with backwards-compat fallback using `matter_type` for books processed before this feature
- **Running header/footer stripping**: OCR header/footer fields are now captured on PageState and stripped from chapter text before merging, improving text quality for both reading and listening
- **Polish cost savings**: Chapters excluded from audiobook (`audio_include=false`) skip the LLM polish call entirely, using mechanical text directly

### Schema changes

Added to `Chapter`:
- `content_type: String` — granular classification (20 values)
- `audio_include: Boolean` — include in audiobook output
- `audio_include_reasoning: String` — LLM explanation

### Files changed (10 files, +351/-24)

| Area | Files | Changes |
|------|-------|---------|
| Schema | `chapter.graphql` | New fields |
| State | `state.go` | ChapterState + PageState header/footer |
| Classify | `structure_helpers.go` | Expanded prompt, schema, StripHeaderFooter |
| Pipeline | `structure.go` | Classify handler, polish skip |
| Load | `load.go` | Load new fields + header/footer + backfill default |
| OCR | `ocr.go` | Capture header/footer on persist |
| Reset | `op_registry.go` | Clear classify reasonings |
| TTS | `tts_generate.go` | Filter by audio_include |
| Tests | `*_test.go` (2 new) | Prompt, unmarshal, header strip, TTS fallback |

## Test plan

- [x] `go test ./internal/jobs/common/...` — passes
- [x] `go test ./internal/jobs/tts_generate/...` — passes
- [x] `go build ./...` — clean
- [ ] End-to-end: process a book through structure phase, verify `audio_include` set on chapters
- [ ] TTS: verify excluded chapters (index, bibliography) are not generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)